### PR TITLE
Untested fix of unnecessary vanilla bug RE: minor clan uprisings

### DIFF
--- a/EMF/EMF_changelog.txt
+++ b/EMF/EMF_changelog.txt
@@ -2,6 +2,7 @@ EMF 4.1 [BETA]
 	(EMF+SWMH) Manual advancement of time in the game lobby has been extended to 1337.1.1, like vanilla, to sate the curiosity of those running into the barrier (starts past 1205.1.1 are still not supported on SWMH, and the bookmarks after that point remain gone)
 	(EMF+SWMH) Castle cultural buildings and cultural retinues have been added for the new German sub-cultures in SWMH, along with the Szekely
 	(EMF+SWMH) FIX: Romanian and Albanians will no longer have two different cultural buildings, and Albanians now have a retinue
+	VANILLA FIX: Minor clan uprisings should no longer coincide with regular provincial revolts
 
 
 EMF 4.0 [2015-08-16]

--- a/EMF/events/rebel_events_horse_lords.txt
+++ b/EMF/events/rebel_events_horse_lords.txt
@@ -1,0 +1,700 @@
+#########################################################
+#
+# Rebel Events for the Horse Lords expansion
+# ( HL.2000 to HL.2499)
+#
+#########################################################
+
+# Written by Henrik Fåhraeus
+
+namespace = HL
+
+# Minor Clan Rebels rise up (temporary rebel title created, with a leader and a war)
+# Triggered from "on_rebel_revolt"
+province_event = {
+	id = HL.2000
+	desc = EVTDESC_HL_2000
+	picture = GFX_evt_steppe_mercenaries
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+
+	trigger = {
+		has_dlc = "Horse Lords"
+		
+		has_empty_holding = yes # To allow a Clan capital
+		
+		owner = {
+			is_nomadic = yes
+			independent = yes
+			culture = ROOT
+			risks_minor_clan_rising = yes
+			in_revolt = no
+			capital_scope = {
+				NOT = { province = ROOT }
+			}
+		}
+		
+		NOT = { # Not if there is already an ongoing Minor Clan revolt
+			owner = {
+				top_liege = {
+					war = yes
+					any_war = {
+						defender = { character = PREV }
+						using_cb = cb_minor_clan_revolt
+#						war_title = ROOT # The county
+					}
+				}
+			}
+		}
+	}
+	
+	immediate = {
+		add_province_modifier = {
+			name = recent_county_uprising
+			duration = 1825 # One year of -100% revolt risk in this county
+		}
+		
+		owner = {
+			top_liege = {
+				save_event_target_as = province_top_liege
+			}
+		}
+	
+		create_character = {
+			random_traits = yes
+			dynasty = random
+			religion = ROOT
+			culture = ROOT
+			female = no
+			age = 20
+			health = 7
+			fertility = 0.7
+			attributes = {
+				martial = 8
+				diplomacy = 9
+			}
+			trait = brave
+			trait = ambitious
+			trait = skilled_tactician
+		}
+		
+		new_character = {
+			create_title = {
+				tier = KING
+				landless = yes
+				temporary = yes
+				rebel = yes
+				culture = ROOT
+				name = "MINOR_CLAN_REVOLT"
+				holder = THIS
+				nomad = yes
+			}
+			
+			set_government_type = nomadic_government
+			
+			wealth = 100
+			
+			random_list = {
+				34 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_with_population_of = event_target:province_top_liege
+						for_population = 10000
+						troops = {
+							light_cavalry = { 200 200 }
+							horse_archers = { 800 800 }
+						}
+						attrition = 0.25
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						attributes = {
+							martial = 7
+						}
+						trait = skilled_tactician
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_with_population_of = event_target:province_top_liege
+							for_population = 10000
+							troops = {
+								light_cavalry = { 200 200 }
+								horse_archers = { 800 800 }
+							}
+							attrition = 0.25
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 31
+						attributes = {
+							martial = 7
+						}
+						trait = skilled_tactician
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_with_population_of = event_target:province_top_liege
+							for_population = 10000
+							troops = {
+								light_cavalry = { 200 200 }
+								horse_archers = { 800 800 }
+							}
+							attrition = 0.25
+							disband_on_peace = yes
+						}
+					}
+				}
+				33 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_with_population_of = event_target:province_top_liege
+						for_population = 10000
+						troops = {
+							light_cavalry = { 150 150 }
+							horse_archers = { 600 600 }
+						}
+						attrition = 0.25
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						attributes = {
+							martial = 7
+						}
+						trait = skilled_tactician
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_with_population_of = event_target:province_top_liege
+							for_population = 10000
+							troops = {
+								light_cavalry = { 150 150 }
+								horse_archers = { 600 600 }
+							}
+							attrition = 0.25
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 31
+						attributes = {
+							martial = 7
+						}
+						trait = skilled_tactician
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_with_population_of = event_target:province_top_liege
+							for_population = 10000
+							troops = {
+								light_cavalry = { 150 150 }
+								horse_archers = { 600 600 }
+							}
+							attrition = 0.25
+							disband_on_peace = yes
+						}
+					}
+				}
+				33 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_with_population_of = event_target:province_top_liege
+						for_population = 10000
+						troops = {
+							light_cavalry = { 100 100 }
+							horse_archers = { 400 400 }
+						}
+						attrition = 0.25
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						attributes = {
+							martial = 7
+						}
+						trait = skilled_tactician
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_with_population_of = event_target:province_top_liege
+							for_population = 10000
+							troops = {
+								light_cavalry = { 100 100 }
+								horse_archers = { 400 400 }
+							}
+							attrition = 0.25
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 31
+						attributes = {
+							martial = 7
+						}
+						trait = skilled_tactician
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_with_population_of = event_target:province_top_liege
+							for_population = 10000
+							troops = {
+								light_cavalry = { 100 100 }
+								horse_archers = { 400 400 }
+							}
+							attrition = 0.25
+							disband_on_peace = yes
+						}
+					}
+				}
+			}
+			
+			# DoW on the province top liege
+			ROOT = {
+				owner = {
+					top_liege = {
+						add_population_scaled = -0.1
+#						set_defacto_vassal = PREVPREVPREV
+						reverse_war = {
+							target = PREVPREVPREV
+							casus_belli = cb_minor_clan_revolt
+							thirdparty_title = ROOT # The county
+						}
+						reverse_opinion = {
+							who = PREVPREVPREV
+							modifier = opinion_evil_tyrant
+						}
+					}
+				}
+			}
+		}
+		
+		owner = {
+			any_liege = { # Inform the lieges
+				character_event = {
+					id = HL.2001
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = EVTOPTA_HL_2000
+	}
+}
+
+character_event = {
+	id = HL.2001
+	desc = EVTDESC_HL_2001
+	picture = GFX_evt_steppe_mercenaries
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_HL_2000
+	}
+}
+
+# Minor Clan rebels seize a holding. Fired from 'on_siege_over_winner'.
+character_event = {
+	id = HL.2005
+	picture = GFX_evt_siege
+	
+	hide_window = yes
+	is_triggered_only = yes
+	
+	desc = OK
+	
+	trigger = {
+		rebel = yes
+		any_war = {
+			attacker = { character = ROOT }
+			using_cb = cb_minor_clan_revolt
+		}
+	}
+	
+	immediate = {
+		FROM = {
+			location = {
+				if = {
+					limit = {
+						NOT = { has_province_modifier = peasant_unrest }
+					}
+					add_province_modifier = {
+						name = peasant_unrest
+						duration = 730
+					}
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = OK
+	}
+}
+
+# Peasant Rebels rise up to reinforce an ongoing provincial peasant revolt
+# Triggered from "on_rebel_revolt"
+province_event = {
+	id = HL.2010
+	desc = EVTDESC_HL_2010
+	picture = GFX_evt_steppe_mercenaries
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+
+	trigger = {
+		has_dlc = "Horse Lords"
+		
+		any_province_holding = {
+			NOT = { holding_type = nomad }
+		}
+
+		# There is already an ongoing peasant revolt for this province
+		owner = {
+			top_liege = {
+				war = yes
+				any_war = {
+					defender = { character = PREV }
+					using_cb = cb_minor_clan_revolt
+#					war_title = ROOT # The county
+				}
+			}
+		}
+	}
+	
+	immediate = {
+	
+		add_province_modifier = {
+			name = recent_county_uprising
+			duration = 1825 # Five years of -100% revolt risk in this county
+		}
+		
+		owner = {
+			top_liege = {
+				any_war = {
+					limit = {
+						defender = { character = PREV }
+						using_cb = cb_minor_clan_revolt
+#						war_title = ROOT # The county
+					}
+					attacker = {
+						random_list = {
+							34 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									attributes = {
+										martial = 7
+									}
+									trait = skilled_tactician
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										troops = {
+											light_cavalry = { 200 200 }
+											horse_archers = { 800 800 }
+										}
+										attrition = 0.25
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									attributes = {
+										martial = 7
+									}
+									trait = skilled_tactician
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										troops = {
+											light_cavalry = { 200 200 }
+											horse_archers = { 800 800 }
+										}
+										attrition = 0.25
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 31
+									attributes = {
+										martial = 7
+									}
+									trait = skilled_tactician
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										troops = {
+											light_cavalry = { 200 200 }
+											horse_archers = { 800 800 }
+										}
+										attrition = 0.25
+										disband_on_peace = yes
+									}
+								}
+							}
+							33 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									attributes = {
+										martial = 7
+									}
+									trait = skilled_tactician
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										troops = {
+											light_cavalry = { 150 150 }
+											horse_archers = { 600 600 }
+										}
+										attrition = 0.25
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									attributes = {
+										martial = 7
+									}
+									trait = skilled_tactician
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										troops = {
+											light_cavalry = { 150 150 }
+											horse_archers = { 600 600 }
+										}
+										attrition = 0.25
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 31
+									attributes = {
+										martial = 7
+									}
+									trait = skilled_tactician
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										troops = {
+											light_cavalry = { 150 150 }
+											horse_archers = { 600 600 }
+										}
+										attrition = 0.25
+										disband_on_peace = yes
+									}
+								}
+							}
+							33 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									attributes = {
+										martial = 7
+									}
+									trait = skilled_tactician
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										troops = {
+											light_cavalry = { 100 100 }
+											horse_archers = { 400 400 }
+										}
+										attrition = 0.25
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									attributes = {
+										martial = 7
+									}
+									trait = skilled_tactician
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										troops = {
+											light_cavalry = { 100 100 }
+											horse_archers = { 400 400 }
+										}
+										attrition = 0.25
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 31
+									attributes = {
+										martial = 7
+									}
+									trait = skilled_tactician
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										troops = {
+											light_cavalry = { 100 100 }
+											horse_archers = { 400 400 }
+										}
+										attrition = 0.25
+										disband_on_peace = yes
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		owner = {
+			any_liege = { # Inform the lieges
+				character_event = {
+					id = HL.2011
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = EVTOPTA_HL_2000
+	}
+}
+
+character_event = {
+	id = HL.2011
+	desc = EVTDESC_HL_2011
+	picture = GFX_evt_steppe_mercenaries
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_HL_2000
+	}
+}

--- a/EMF/events/rebel_events_horse_lords.txt
+++ b/EMF/events/rebel_events_horse_lords.txt
@@ -22,6 +22,8 @@ province_event = {
 	trigger = {
 		has_dlc = "Horse Lords"
 		
+		not = { num_of_settlements = 1 } # EMF: only happen in empty nomadic provinces
+
 		has_empty_holding = yes # To allow a Clan capital
 		
 		owner = {
@@ -404,8 +406,10 @@ province_event = {
 	trigger = {
 		has_dlc = "Horse Lords"
 		
-		any_province_holding = {
-			NOT = { holding_type = nomad }
+		NOT = { # EMF: only in nomad provinces
+			any_province_holding = {
+				NOT = { holding_type = nomad }
+			}
 		}
 
 		# There is already an ongoing peasant revolt for this province


### PR DESCRIPTION
These types of revolts-- and their reinforcements-- should no longer happen whenever any old provincial revolt happens if I understand `on_rebel_revolt` correctly, because they are now restricted to firing only upon nomadic provinces.