### PR TITLE
AED: Protect e_seljuk_turks & copy_title_laws on kingdom-demotion

### DIFF
--- a/EMF/EMF_changelog.txt
+++ b/EMF/EMF_changelog.txt
@@ -6,6 +6,7 @@ EMF 4.1 [BETA]
 		FIX: Robert Guiscard no longer has an overlapping war (2 CBs at once) in the Alexiad (1081) start
 	Robert Guiscard's 5 Norman-Byzantine Wars from 1066 until his death have been removed in favor of an invasion of the Balkans in 1081.4.1 (Alexiad start), for historical accuracy.
 		However, it is likely that his earlier Italian campaigns against the ERE will receive special treatment (with a custom CB) in the future.
+	FIX: The Seljuks will no longer immediately lose their titular empire-tier title gained when they first spawn/invade (pre-1066 starts)
 	VANILLA FIX: Reduced the odds of an AI character with theology focus taking the option to become a heretic from 33% to 20%
 
 

--- a/EMF/events/emf_empires.txt
+++ b/EMF/events/emf_empires.txt
@@ -28,7 +28,7 @@ character_event = {
 			or = {
 				and = {
 					ROOT = { not = { realm_size = 100 } }
-					not = {
+					nor = {
 						title = e_hip
 						title = e_rebels
 						title = e_pirates
@@ -37,6 +37,7 @@ character_event = {
 						title = e_latin_empire
 						title = e_timurids
 						title = e_mexikha
+						title = e_seljuk_turks # Only until we convert title destruction to be time-delayed after fulfilling AED conditions
 						and = {
 							or = {
 								title = e_golden_horde
@@ -134,7 +135,12 @@ character_event = {
 
 		if = {
 			limit = { event_target:emf_new_title = { always = yes } } # We'll be creating a king title
-			event_target:emf_new_title = { grant_title = ROOT }
+			primary_title = {
+				event_target:emf_new_title = {
+					grant_title = ROOT
+					copy_title_laws = PREV
+				}
+			}
 		}
 		
 		random_demesne_title = {
@@ -145,7 +151,7 @@ character_event = {
 				or = {
 					and = {
 						ROOT = { not = { realm_size = 100 } }
-						not = {
+						nor = {
 							title = e_hip
 							title = e_rebels
 							title = e_pirates
@@ -154,6 +160,7 @@ character_event = {
 							title = e_latin_empire
 							title = e_timurids
 							title = e_mexikha
+							title = e_seljuk_turks
 							and = {
 								or = {
 									title = e_golden_horde
@@ -177,7 +184,8 @@ character_event = {
 				}
 			}
 			
-			unsafe_destroy_landed_title = THIS
+			#unsafe_destroy_landed_title = THIS
+			destroy_landed_title = THIS
 			
 			hidden_tooltip = {
 				save_event_target_as = emf_crier_dead_title


### PR DESCRIPTION
- Exempt `e_seljuk_turks` from AED (only until AED is upgraded to only demote empires after a dynamically-timed delay since fulfilling the demotion conditions).
- When demoting to a new kingdom title, copy the laws from the old empire-tier title first.
- Do not use the `unsafe_` version of `destroy_landed_title` for now (too many crazy landless & other weird empire-tier titles at this time, needs sorting-out)