### PR TITLE
EMF+ArkoCoA module obsolete

### DIFF
--- a/EMF+ArkoCoA/common/religions/ArkoCoA_religions.txt
+++ b/EMF+ArkoCoA/common/religions/ArkoCoA_religions.txt
@@ -1,5 +1,0 @@
-
-pagan_group = {
-	has_coa_on_barony_only = no
-	pagan = { graphicalculture = africangfx }
-}


### PR DESCRIPTION
ARKOpack takes care of its own folderized 00_religions.txt override now.