### PR TITLE
Elective monarchy faction nerfs & improved logic

### DIFF
--- a/EMF/EMF_changelog.txt
+++ b/EMF/EMF_changelog.txt
@@ -13,6 +13,7 @@ EMF 4.01 [BETA]
 		Invasion uses a custom CB designed to minimize the unlanding of original characters and their subsequent replacement with Mongol-cultured feudal lords. The Mongols were indeed rather "hands-off" overlords, and it should be much more fun to be conquered by the Mongols (merely the beginning of a new era rather than a reason to ragequit)!
 		Mongol Empire will no longer convert away from the Tengri faith until at least 30 years after its arrival.
 		The *Conqueror* trait (which makes characters particularly ruthless) will stop being applied to Mongol invaders after the year 1300
+	Elective monarchy faction logic significantly improved, toward the goal of generally reducing the faction's likelihood to revolt
 	Robert Guiscard's 5 Norman-Byzantine Wars from 1066 until his death have been removed in favor of an invasion of the Balkans in 1081.4.1 (Alexiad start), for historical accuracy
 		However, it is likely that his earlier Italian campaigns against the ERE will receive special treatment (with a custom CB) in the future.
 	Vanilla map: Duchy of Flanders de jure moved to Kingdom of France

--- a/EMF/common/objectives/00_factions.txt
+++ b/EMF/common/objectives/00_factions.txt
@@ -1827,7 +1827,7 @@ faction_succ_feudal_elective = {
 				any_demesne_title = {
 					temporary = yes
 				}
-			}			
+			}
 		}
 		NOT = { religion_group = muslim }
 		primary_title = { higher_tier_than = BARON }
@@ -1915,11 +1915,16 @@ faction_succ_feudal_elective = {
 			NOT = { in_faction = faction_succ_primogeniture }
 			NOT = { in_faction = faction_succ_gavelkind }
 		}
-	}		
+	}
 	
 	# AI creation weight
 	chance = {
 		factor = 1
+		
+		modifier = { # EMF: Generally slow-down FE faction joins
+			factor = 0.8
+			always = yes
+		}
 		
 		modifier = {
 			factor = 0.2
@@ -1979,6 +1984,23 @@ faction_succ_feudal_elective = {
 				dynasty = FROM
 			}
 		}
+
+		modifier = { # EMF: Why would royal-house nobles try to force a feudal elective monarchy?
+			factor = 0.1 # They usually wouldn't ...
+				holder_scope = {
+					or = {
+						dynasty = FROM
+						is_close_relative = FROM
+					}
+				}
+				current_heir = { # ... unless the current heir to the title is not a relative.
+					or = {
+						dynasty = FROM
+						is_close_relative = FROM
+					}
+				}
+			}
+		}
 		
 		# If next in line under seniority, choose that plot insetead
 		modifier = {
@@ -2015,14 +2037,14 @@ faction_succ_feudal_elective = {
 		modifier = {
 			factor = 0
 			FROM = {
-				OR = {
-					AND = {
-						NOT = { leads_faction = faction_succ_feudal_elective }
-						opinion = { who = LIEGE value = 50 } 
+				or = {
+					and = {
+						not = { leads_faction = faction_succ_feudal_elective }
+						opinion = { who = LIEGE value = 30 } 
 					}
-					AND = {
+					and = {
 						leads_faction = faction_succ_feudal_elective
-						opinion = { who = LIEGE value = 75 } 
+						opinion = { who = LIEGE value = 60 } 
 					}
 				}
 			}
@@ -2036,11 +2058,12 @@ faction_succ_feudal_elective = {
 		modifier = {
 			factor = 0
 			FROM = { 
-				opinion = { who = LIEGE value = 25 } 
-				NOT = {
+				opinion = { who = LIEGE value = 20 } 
+				nor = {
 					trait = deceitful
 					trait = ambitious
 					trait = envious
+					trait = arbitrary
 				}			
 			}
 		}		
@@ -2049,10 +2072,11 @@ faction_succ_feudal_elective = {
 			factor = 0
 			FROM = {
 				opinion = { who = LIEGE value = 50 } 
-				OR = {
+				or = {
 					trait = deceitful
 					trait = ambitious
 					trait = envious
+					trait = arbitrary
 				}				
 			}
 		}
@@ -2096,6 +2120,14 @@ faction_succ_feudal_elective = {
 			FROM = { trait = slow }
 		}
 		modifier = {
+			factor = 0.25
+			FROM = { trait = humble }
+		}
+		modifier = {
+			factor = 0.25
+			FROM = { trait = just }
+		}
+		modifier = {
 			factor = 0.5
 			FROM = { trait = kind }
 		}
@@ -2106,14 +2138,6 @@ faction_succ_feudal_elective = {
 		modifier = {
 			factor = 0.5
 			FROM = { trait = honest }
-		}
-		modifier = {
-			factor = 0.75
-			FROM = { trait = humble }
-		}
-		modifier = {
-			factor = 0.75
-			FROM = { trait = just }
 		}
 		modifier = {
 			factor = 1.5
@@ -2128,20 +2152,12 @@ faction_succ_feudal_elective = {
 			FROM = { trait = arbitrary }
 		}
 		modifier = {
+			factor = 1.5
+			FROM = { trait = deceitful }
+		}
+		modifier = {
 			factor = 2.0
 			FROM = { trait = envious }
-		}
-		modifier = {
-			factor = 2.0
-			FROM = { trait = greedy }
-		}
-		modifier = {
-			factor = 2.0
-			FROM = { trait = impaler }
-		}
-		modifier = {
-			factor = 2.0
-			FROM = { trait = deceitful }
 		}
 		modifier = {
 			factor = 4.0
@@ -2153,6 +2169,11 @@ faction_succ_feudal_elective = {
 	membership = {
 		factor = 1
 		
+		modifier = { # EMF: Generally slow-down FE faction joins
+			factor = 0.8
+			always = yes
+		}
+
 		modifier = {
 			factor = 0.2
 			pacifist = yes
@@ -2177,7 +2198,7 @@ faction_succ_feudal_elective = {
 				}
 			}
 		}
-		
+
 		modifier = {
 			factor = 0
 			OR = {
@@ -2186,7 +2207,7 @@ faction_succ_feudal_elective = {
 				in_faction = faction_succ_gavelkind
 			}
 		}
-		
+
 		modifier = {
 			factor = 0
 			
@@ -2221,17 +2242,17 @@ faction_succ_feudal_elective = {
 		
 		modifier = {
 			factor = 0
-			OR = {
-				AND = {
-					NOT = { in_faction = faction_succ_feudal_elective }
-					opinion = { who = LIEGE value = 50 } 
+			or = {
+				and = {
+					not = { in_faction = faction_succ_feudal_elective }
+					opinion = { who = LIEGE value = 30 } 
 				}
-				AND = {
+				and = {
 					in_faction = faction_succ_feudal_elective
-					opinion = { who = LIEGE value = 75 } 
+					opinion = { who = LIEGE value = 60 } 
 				}
 			}
-			NOT = {	
+			not = {	
 				has_opinion_modifier = {
 					who = FROM
 					modifier = opinion_coerced_into_joining_faction
@@ -2264,13 +2285,14 @@ faction_succ_feudal_elective = {
 		
 		modifier = {
 			factor = 0
-			opinion = { who = LIEGE value = 25 } 
-			NOT = {
+			opinion = { who = LIEGE value = 20 } 
+			nor = {
 				trait = deceitful
 				trait = ambitious
 				trait = envious
+				trait = arbitrary
 			}
-			NOT = {	
+			not = {	
 				has_opinion_modifier = {
 					who = FROM
 					modifier = opinion_coerced_into_joining_faction
@@ -2281,12 +2303,13 @@ faction_succ_feudal_elective = {
 		modifier = {
 			factor = 0
 			opinion = { who = LIEGE value = 50 } 
-			OR = {
+			or = {
 				trait = deceitful
 				trait = ambitious
 				trait = envious
+				trait = arbitrary
 			}
-			NOT = {	
+			not = {	
 				has_opinion_modifier = {
 					who = FROM
 					modifier = opinion_coerced_into_joining_faction
@@ -2294,6 +2317,52 @@ faction_succ_feudal_elective = {
 			}			
 		}
 		
+		# Try to exclude people who should rather support a claimant (EMF)
+		modifier = {
+			factor = 0
+			FROMFROM = {
+				holder_scope = {
+					OR = {
+						NOT = { culture = ROOT }
+						NOT = { religion = ROOT }
+					}
+					any_demesne_title = {
+						OR = {
+							is_primary_holder_title = yes
+							higher_tier_than = DUKE
+						}
+						ROOT = {
+							primary_title = {
+								de_jure_liege_or_above = PREVPREV
+							}
+						}
+						any_claimant = {
+							culture = ROOT
+							religion = ROOT
+						}
+					}
+				}
+			}
+		}
+
+		modifier = { # EMF: Why would royal-house nobles try to force a feudal elective monarchy?
+			factor = 0.1 # They usually wouldn't ...
+			FROMFROM = {
+				holder_scope = {
+					or = {
+						dynasty = ROOT
+						is_close_relative = ROOT
+					}
+				}
+				current_heir = { # ... unless the current heir to the title is not a relative.
+					or = {
+						dynasty = ROOT
+						is_close_relative = ROOT
+					}
+				}
+			}
+		}
+
 		modifier = {
 			factor = 1000
 			has_opinion_modifier = {
@@ -2301,7 +2370,7 @@ faction_succ_feudal_elective = {
 				modifier = opinion_coerced_into_joining_faction
 			}
 		}
-		
+
 		modifier = {
 			factor = 0.01
 			trait = content
@@ -2323,6 +2392,14 @@ faction_succ_feudal_elective = {
 			trait = slow
 		}
 		modifier = {
+			factor = 0.25
+			trait = humble
+		}
+		modifier = {
+			factor = 0.25
+			trait = just
+		}
+		modifier = {
 			factor = 0.5
 			trait = kind
 		}
@@ -2333,14 +2410,6 @@ faction_succ_feudal_elective = {
 		modifier = {
 			factor = 0.5
 			trait = honest
-		}
-		modifier = {
-			factor = 0.75
-			trait = humble
-		}
-		modifier = {
-			factor = 0.75
-			trait = just
 		}
 		modifier = {
 			factor = 1.5
@@ -2355,20 +2424,12 @@ faction_succ_feudal_elective = {
 			trait = arbitrary
 		}
 		modifier = {
+			factor = 1.5
+			trait = deceitful
+		}
+		modifier = {
 			factor = 2.0
 			trait = envious
-		}
-		modifier = {
-			factor = 2.0
-			trait = greedy
-		}
-		modifier = {
-			factor = 2.0
-			trait = impaler
-		}
-		modifier = {
-			factor = 2.0
-			trait = deceitful
 		}
 		modifier = {
 			factor = 4.0


### PR DESCRIPTION
- Elective faction has been significantly nerfed now. Hope this is neither too much nor too little.
- @escalonn: I checked the CB for the elective faction, and if the title whose succession law is in question is already / becomes an elective monarchy, the revolt immediately invalidates, so I don't know what you were seeing in That One Observe.