### PR TITLE
Magyar starting troops & Commander minor title

### DIFF
--- a/EMF+SWMH/history/characters/hungarian.txt
+++ b/EMF+SWMH/history/characters/hungarian.txt
@@ -9489,7 +9489,7 @@
 		# Boost the initial strength of the Magyars
 		effect = {
 			spawn_unit = {
-				province = 544 # Korsun
+				province = 1147 # Bacau
 				owner = ROOT
 				leader = ROOT
 				troops = {
@@ -9498,7 +9498,7 @@
 					archers = { 325 325 }
 				}
 				attrition = 0.5
-                                earmark = start_troops
+				earmark = start_troops
 			}
 			create_character = {
 				random_traits = yes
@@ -9508,13 +9508,13 @@
 				female = no
 				age = 23
 				attributes = {
-					martial = 6
+					martial = 10
 				}
-				trait = skilled_tactician
+				trait = brilliant_strategist
 			}
 			new_character = {
 				spawn_unit = {
-					province = 544 # Korsun
+					province = 1147 # Bacau
 					owner = ROOT
 					leader = THIS
 					troops = {
@@ -9523,7 +9523,7 @@
 						archers = { 325 325 }
 					}
 					attrition = 0.5
-                                        earmark = start_troops
+					earmark = start_troops
 				}
 			}
 			create_character = {
@@ -9534,13 +9534,13 @@
 				female = no
 				age = 27
 				attributes = {
-					martial = 6
+					martial = 10
 				}
-				trait = skilled_tactician
+				trait = brilliant_strategist
 			}
 			new_character = {
 				spawn_unit = {
-					province = 544 # Korsun
+					province = 1147 # Bacau
 					owner = ROOT
 					leader = THIS
 					troops = {
@@ -9549,7 +9549,7 @@
 						archers = { 325 325 }
 					}
 					attrition = 0.5
-                                        earmark = start_troops
+					earmark = start_troops
 				}
 			}
 		}

--- a/EMF+SWMH/history/characters/hungarian.txt
+++ b/EMF+SWMH/history/characters/hungarian.txt
@@ -9472,7 +9472,7 @@
 	culture="hungarian"
 	father=159138
 	mother=159139
-	martial=8
+	martial=10
 	diplomacy=7
 	trait=ambitious
 	trait=gregarious
@@ -9488,16 +9488,18 @@
 	867.1.1 = {
 		# Boost the initial strength of the Magyars
 		effect = {
-			spawn_unit = {
+			spawn_unit = { #1
 				province = 1147 # Bacau
 				owner = ROOT
-				leader = ROOT
-				troops = {
-					light_infantry = { 1626 1626 }
-					heavy_infantry = { 75 75 }
-					archers = { 325 325 }
+				troops =
+				{
+					horse_archers = { 1350 1350 }
+					light_cavalry = { 800 800 }
+					light_infantry = { 270 270 }
+					knights = { 130 130 }
 				}
-				attrition = 0.5
+				attrition = 0.25
+				merge = yes
 				earmark = start_troops
 			}
 			create_character = {
@@ -9510,19 +9512,23 @@
 				attributes = {
 					martial = 10
 				}
-				trait = brilliant_strategist
+				trait = skilled_tactician
 			}
 			new_character = {
-				spawn_unit = {
+				give_minor_title = title_commander
+
+				spawn_unit = { #2
 					province = 1147 # Bacau
 					owner = ROOT
-					leader = THIS
-					troops = {
-						light_infantry = { 1626 1626 }
-						heavy_infantry = { 75 75 }
-						archers = { 325 325 }
+					troops =
+					{
+						horse_archers = { 1350 1350 }
+						light_cavalry = { 800 800 }
+						light_infantry = { 270 270 }
+						knights = { 130 130 }
 					}
-					attrition = 0.5
+					attrition = 0.25
+					merge = yes
 					earmark = start_troops
 				}
 			}
@@ -9539,16 +9545,110 @@
 				trait = brilliant_strategist
 			}
 			new_character = {
-				spawn_unit = {
+				give_minor_title = title_commander
+
+				spawn_unit = { #3
 					province = 1147 # Bacau
 					owner = ROOT
-					leader = THIS
-					troops = {
-						light_infantry = { 1626 1626 }
-						heavy_infantry = { 75 75 }
-						archers = { 325 325 }
+					troops =
+					{
+						horse_archers = { 1350 1350 }
+						light_cavalry = { 800 800 }
+						light_infantry = { 270 270 }
+						knights = { 130 130 }
 					}
-					attrition = 0.5
+					attrition = 0.25
+					merge = yes
+					earmark = start_troops
+				}
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 25
+				attributes = {
+					martial = 10
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				give_minor_title = title_commander
+
+				spawn_unit = { #4
+					province = 1147 # Bacau
+					owner = ROOT
+					troops =
+					{
+						horse_archers = { 1350 1350 }
+						light_cavalry = { 800 800 }
+						light_infantry = { 270 270 }
+						knights = { 130 130 }
+					}
+					attrition = 0.25
+					merge = yes
+					earmark = start_troops
+				}
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 29
+				attributes = {
+					martial = 10
+				}
+				trait = brilliant_strategist
+			}
+			new_character = {
+				give_minor_title = title_commander
+
+				spawn_unit = { #5
+					province = 1147 # Bacau
+					owner = ROOT
+					troops =
+					{
+						horse_archers = { 1350 1350 }
+						light_cavalry = { 800 800 }
+						light_infantry = { 270 270 }
+						knights = { 130 130 }
+					}
+					attrition = 0.25
+					merge = yes
+					earmark = start_troops
+				}
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 32
+				attributes = {
+					martial = 10
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				give_minor_title = title_commander
+
+				spawn_unit = { #6
+					province = 1147 # Bacau
+					owner = ROOT
+					troops =
+					{
+						horse_archers = { 1350 1350 }
+						light_cavalry = { 800 800 }
+						light_infantry = { 270 270 }
+						knights = { 130 130 }
+					}
+					attrition = 0.25
+					merge = yes
 					earmark = start_troops
 				}
 			}

--- a/EMF+SWMH/history/characters/hungarian.txt
+++ b/EMF+SWMH/history/characters/hungarian.txt
@@ -1,0 +1,9953 @@
+1621 = {
+	name="Márton"
+	# AKA: Marton
+	dynasty=101570
+	martial=5
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=4409
+	1027.1.1 = {
+		birth = yes
+	}
+	1049.1.1 = {
+		add_spouse=4411
+	}
+	1080.1.1 = {
+		death = yes
+	}
+}
+#modified
+6847 = {
+	name="Csák"
+        dynasty = 1000100560 # Kér
+	religion=tengri_pagan
+	culture=hungarian
+	840.1.1={
+		birth = yes
+	}
+	897.1.1={
+		death = yes
+	}
+}
+
+6848 = {
+	name="Gyula"
+        dynasty = 1000100561 # Keszi
+	religion=tengri_pagan
+	culture=hungarian
+	841.1.1={
+		birth = yes
+	}
+	895.1.1={
+		death = yes
+	}
+}
+
+20356 = {
+	name="György"
+	dynasty=19010
+	martial=8
+	diplomacy=7
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="tough_soldier"
+	1020.1.1 = {
+		birth="1020.1.1"
+	}
+	1045.1.1 = {
+		add_spouse=4434
+	}
+	1083.1.1 = {
+		death="1083.1.1"
+	}
+}
+
+20360 = {
+	name="Ottó"
+	# AKA: Otto
+	dynasty=101568
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="skilled_tactician"
+	1012.1.1 = {
+		birth="1012.1.1"
+	}
+	1038.1.1 = {
+		add_spouse=4389
+	}
+	1082.1.1 = {
+		death="1082.1.1"
+	}
+}
+
+20362 = {
+	name="Gút"
+	# AKA: Gut
+	dynasty=19052
+	martial=8
+	diplomacy=6
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="amateurish_plotter"
+	father=20357
+	1005.1.1 = {
+		birth="1005.1.1"
+	}
+	1065.1.1 = {
+		death="1065.1.1"
+	}
+}
+
+20363 = {
+	name="Keled"
+	dynasty=19052
+	martial=8
+	diplomacy=5
+	intrigue=7
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="deceitful"
+	trait="grey_eminence"
+	father=20357
+	1010.1.1 = {
+		birth="1010.1.1"
+	}
+	1033.1.2 = {
+		add_spouse=491
+	}
+	1068.1.1 = {
+		death="1068.1.1"
+	}
+}
+
+20364 = {
+	name="Elek"
+	dynasty=101566
+	martial=6
+	diplomacy=8
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="kind"
+	trait="tough_soldier"
+	father=4379
+	1024.1.1 = {
+		birth="1024.1.1"
+	}
+	1050.1.1 = {
+		add_spouse=4384
+	}
+	1083.1.1 = {
+		death="1083.1.1"
+	}
+}
+
+20365 = {
+	name="Máté"
+	# AKA: Mate
+	dynasty=101565
+	martial=8
+	diplomacy=4
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="clubfooted"
+	trait="scholarly_theologian"
+	1023.1.1 = {
+		birth="1023.1.1"
+	}
+	1040.1.1 = {
+		add_spouse=4365
+	}
+	1078.1.1 = {
+		death="1078.1.1"
+	}
+}
+
+20366 = {
+	name="Péter"
+	dynasty=19000
+	martial=5
+	diplomacy=7
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="flamboyant_schemer"
+	father=20371
+	mother=499
+	1017.1.1 = {
+		birth="1017.1.1"
+	}
+	1040.1.1 = {
+		add_spouse=20375
+	}
+	1080.1.1 = {
+		death="1080.1.1"
+	}
+}
+
+20367 = {
+	name="Ince"
+	dynasty=101569
+	martial=7
+	diplomacy=6
+	intrigue=7
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="underhanded_rogue"
+	father=4399
+	1047.1.1 = {
+		birth="1047.1.1"
+	}
+	1095.1.1 = {
+		death="1095.1.1"
+	}
+}
+
+20368 = {
+	name="Lampert"
+	dynasty=708
+	martial=4
+	diplomacy=4
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="underhanded_rogue"
+	father=470
+	mother=763
+	1051.1.1 = {
+		birth="1051.1.1"
+	}
+	1095.1.1 = {
+		death="1095.1.1"
+	}
+}
+
+20369 = {
+	name="Lampert"
+	dynasty=19053
+	martial=4
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="stutter"
+	trait="tough_soldier"
+	father=4429
+	1055.1.1 = {
+		birth="1055.1.1"
+	}
+	1132.1.1 = {
+		death="1132.1.1"
+	}
+}
+
+20370 = {
+	name="Zsófia"
+	# AKA: Zsofia
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=5
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="craven"
+	trait="charismatic_negotiator"
+	father=472
+	mother=479
+	1064.1.1 = {
+		birth="1064.1.1"
+	}
+	1120.1.1 = {
+		death="1120.1.1"
+	}
+}
+
+20371 = {
+	name="Sámuel"
+	# AKA: Samuel
+	dynasty=19000
+	martial=6
+	diplomacy=4
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="greedy"
+	trait="tough_soldier"
+	990.1.2 = {
+		birth="990.1.2"
+	}
+	1010.1.1 = {
+		add_spouse=499
+	}
+	1044.7.1 = {
+		death="1044.7.1"
+	}
+}
+
+20372 = {
+	name="Belenik"
+	dynasty=101563
+	martial=5
+	diplomacy=8
+	intrigue=6
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="underhanded_rogue"
+	1024.1.1 = {
+		birth="1024.1.1"
+	}
+	1048.1.1 = {
+		add_spouse=4444
+	}
+	1081.1.1 = {
+		death="1081.1.1"
+	}
+}
+
+20373 = {
+	name="Mihály"
+	# AKA: Mihaly
+	dynasty=101564
+	martial=4
+	diplomacy=5
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="charismatic_negotiator"
+	1039.1.1 = {
+		birth="1039.1.1"
+	}
+	1064.1.1 = {
+		add_spouse=4366
+	}
+	1066.1.1 = {
+	employer=20365
+	}
+	1087.1.1 = {
+		death="1087.1.1"
+	}
+}
+
+20374 = {
+	name="Ilya"
+	dynasty=101573
+	martial=5
+	diplomacy=4
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="tough_soldier"
+	1031.1.1 = {
+		birth="1031.1.1"
+	}
+	1066.1.1 = {
+	employer=476
+	}
+	1083.1.1 = {
+		death="1083.1.1"
+	}
+}
+
+20375 = {
+	name="Emese"
+	female=yes
+	dynasty=180
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="detached_priest"
+	1025.1.1 = {
+		birth="1025.1.1"
+	}
+	1086.1.1 = {
+		death="1086.1.1"
+	}
+}
+
+20376 = {
+	name="Mihály"
+	# AKA: Mihaly
+	dynasty=19000
+	martial=7
+	diplomacy=4
+	intrigue=7
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="charitable"
+	trait="tough_soldier"
+	father=20366
+	mother=20375
+	1042.1.1 = {
+		birth="1042.1.1"
+	}
+	1102.1.1 = {
+		death="1102.1.1"
+	}
+}
+
+20377 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19000
+	martial=4
+	diplomacy=5
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="honest"
+	trait="diligent"
+	trait="martial_cleric"
+	father=20366
+	mother=20375
+	1045.1.1 = {
+		birth="1045.1.1"
+	}
+	1099.1.1 = {
+		death="1099.1.1"
+	}
+}
+
+20378 = {
+	name="Keled"
+	dynasty=19052
+	martial=9
+	diplomacy=5
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="cynical"
+	trait="misguided_warrior"
+	father=20363
+	mother=491
+	1034.1.1 = {
+		birth="1034.1.1"
+	}
+	1056.1.2 = {
+		add_spouse=4363
+	}
+	1086.1.1 = {
+		death="1086.1.1"
+	}
+}
+
+20379 = {
+	name="Bény"
+	# AKA: Beny
+	dynasty=19052
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="underhanded_rogue"
+	father=20363
+	mother=491
+	1036.1.1 = {
+		birth="1036.1.1"
+	}
+	1096.1.1 = {
+		death="1096.1.1"
+	}
+}
+
+219001 = {
+	name="Almos"
+	dynasty=100442
+	martial=4
+	diplomacy=7
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="skilled_tactician"
+	1150.1.1 = {
+		birth = yes
+	}
+	1200.1.1 = {
+		death = yes
+	}
+}
+
+219003 = {
+	name="Tamás"
+	dynasty=100444
+	martial=8
+	diplomacy=4
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="wroth"
+	trait="flamboyant_schemer"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219004 = {
+	name="Donát"
+	# AKA: Donat
+	dynasty=100445
+	martial=5
+	diplomacy=7
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="scholarly_theologian"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219005 = {
+	name="Gellért"
+	# AKA: Gellert
+	dynasty=100450
+	martial=6
+	diplomacy=8
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=93654
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219006 = {
+	name="Kornél"
+	# AKA: Kornel
+	dynasty=100451
+	martial=6
+	diplomacy=5
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="proud"
+	trait="skilled_tactician"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219007 = {
+	name="Bernát"
+	# AKA: Bernat
+	dynasty=100452
+	martial=4
+	diplomacy=5
+	intrigue=8
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="amateurish_plotter"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219008 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=100453
+	martial=7
+	diplomacy=6
+	intrigue=8
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="underhanded_rogue"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219009 = {
+	name="Móric"
+	# AKA: Moric
+	dynasty=100454
+	martial=7
+	diplomacy=5
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="cynical"
+	trait="temperate"
+	trait="amateurish_plotter"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219010 = {
+	name="Ádárn"
+	# AKA: adarn
+	dynasty=100460
+	martial=4
+	diplomacy=4
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219011 = {
+	name="Márton"
+	# AKA: Marton
+	#dynasty=100462
+	martial=7
+	diplomacy=6
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="proud"
+	trait="honest"
+	trait="scholarly_theologian"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219013 = {
+	name="János"
+	# AKA: Janos
+	dynasty=100517
+	martial=6
+	diplomacy=7
+	intrigue=8
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="martial_cleric"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219014 = {
+	name="Gábriel"
+	# AKA: Gabriel
+	dynasty=100518
+	martial=5
+	diplomacy=8
+	intrigue=5
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219015 = {
+	name="Imre"
+	dynasty=100519
+	martial=6
+	diplomacy=4
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="greedy"
+	trait="tough_soldier"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219016 = {
+	name="Mátyás"
+	# AKA: Matyas
+	dynasty=100520
+	martial=7
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="brave"
+	trait="tough_soldier"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219017 = {
+	name="Móric"
+	# AKA: Moric
+	dynasty=100521
+	martial=7
+	diplomacy=8
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219018 = {
+	name="Ágoston"
+	# AKA: agoston
+	dynasty=100523
+	martial=4
+	diplomacy=8
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="craven"
+	trait="martial_cleric"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219019 = {
+	name="Elemér"
+	# AKA: Elemer
+	dynasty=100524
+	martial=5
+	diplomacy=8
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219020 = {
+	name="Bertalan"
+	dynasty=100525
+	martial=4
+	diplomacy=7
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="humble"
+	trait="cynical"
+	trait="amateurish_plotter"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219021 = {
+	name="Gáspár"
+	# AKA: Gaspar
+	dynasty=100533
+	martial=5
+	diplomacy=5
+	intrigue=7
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219022 = {
+	name="Gábor"
+	dynasty=100537
+	martial=5
+	diplomacy=7
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="fortune_builder"
+	father=93638
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219023 = {
+	name="Elek"
+	dynasty=100538
+	martial=5
+	diplomacy=7
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="greedy"
+	trait="flamboyant_schemer"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219024 = {
+	name="Konrád"
+	# AKA: Konrad
+	dynasty=100539
+	martial=6
+	diplomacy=8
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="slothful"
+	trait="gluttonous"
+	trait="tough_soldier"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219025 = {
+	name="Attila"
+	dynasty=100540
+	martial=4
+	diplomacy=4
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="greedy"
+	trait="craven"
+	trait="martial_cleric"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219500 = {
+	name="Béla"
+	dynasty=708
+	martial=4
+	diplomacy=6
+	intrigue=8
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=219510
+	mother=222573
+	1148.1.1 = {
+		birth="1148.1.1"
+	}
+	1163.1.2 = {
+		add_spouse=213528
+	}
+	1163.6.19= {
+		add_claim = k_hungary
+		add_claim = k_croatia
+	}	
+	1169.1.2 = {
+		remove_spouse=213528
+	}
+	1172.1.2 = {
+		add_spouse=223593
+	}
+	1172.3.4= {
+		remove_claim = k_hungary
+		remove_claim = k_croatia
+	}
+	1186.1.2 = {
+		add_spouse=205515
+	}
+	1196.4.23 = {
+		death="1196.4.23"
+	}
+}
+
+219501 = {
+	name="Imre"
+	dynasty=708
+	martial=8
+	diplomacy=8
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=219500
+	mother=223593
+	1174.1.2 = {
+		birth="1174.1.2"
+	}
+	1198.1.2 = {
+		add_spouse=210503
+	}
+	1204.11.30 = {
+		death="1204.11.30"
+	}
+}
+
+219502 = {
+	name="András"
+	# AKA: Andras
+	dynasty=708
+	martial=7
+	diplomacy=5
+	intrigue=8
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="honest"
+	trait="tough_soldier"
+	father=219500
+	mother=223593
+	1176.1.2 = {
+		birth="1176.1.2"
+	}
+	1202.1.2 = {
+		add_spouse=212946
+	}
+	1215.2.2 = {
+		add_spouse=98024
+	}
+	1234.5.14 = {
+		add_spouse=98025
+	}
+	1235.9.21 = {
+		death="1235.9.21"
+	}
+}
+
+219503 = {
+	name="Konstancia"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=4
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="cynical"
+	trait="martial_cleric"
+	father=219500
+	mother=223593
+	1180.1.2 = {
+		birth="1180.1.2"
+	}
+	1240.12.6 = {
+		death="1240.12.6"
+	}
+}
+
+219504 = {
+	name="Erzebet"
+	female=yes
+	dynasty=708
+	martial=8
+	diplomacy=8
+	intrigue=8
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="martial_cleric"
+	father=219500
+	mother=223593
+	1178.1.2 = {
+		birth="1178.1.2"
+	}
+	1228.1.2 = {
+		death="1228.1.2"
+	}
+}
+
+219505 = {
+	name="Erzebet"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=7
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="temperate"
+	trait="flamboyant_schemer"
+	father=219530
+	mother=218511
+	1128.1.2 = {
+		birth="1128.1.2"
+	}
+	1154.7.21 = {
+		death="1154.7.21"
+	}
+}
+
+219510 = {
+	name="Géza"
+	# AKA: Geza
+	dynasty=708
+	martial=6
+	diplomacy=7
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="kind"
+	trait="brave"
+	trait="underhanded_rogue"
+	father=219530
+	mother=218511
+	1130.1.2 = {
+		birth="1130.1.2"
+	}
+	1141.2.13 = {
+	capital=k_hungary
+	}
+	#1146.1.2 = {
+	#	add_spouse=222573
+	#}
+	1162.5.31 = {
+		death="1162.5.31"
+	}
+}
+
+219511 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=708
+	martial=8
+	diplomacy=7
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="craven"
+	trait="martial_cleric"
+	father=219510
+	mother=222573
+	1147.7.2 = {
+		birth="1147.7.2"
+	}
+	1167.1.2 = {
+		add_spouse=98022
+	}
+	1168.1.2 = {
+	remove_spouse=98022
+	}
+	1168.5.2 = {
+		add_spouse=212542
+	}
+	1172.3.4 = {
+		death="1172.3.4"
+	}
+}
+
+219512 = {
+	name="Erzsebeth"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=7
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="deceitful"
+	trait="flamboyant_schemer"
+	father=219510
+	mother=222573
+	1140.1.2 = {
+		birth = yes
+	}
+	1194.1.2 = {
+		death="1194.1.2"
+	}
+}
+
+219515 = {
+	name="Margit"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=6
+	intrigue=8
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="arbitrary"
+	trait="harelip"
+	trait="martial_cleric"
+	father=219500
+	mother=223593
+	1175.1.2 = {
+		birth="1175.1.2"
+	}
+	1229.3.29 = {
+		death="1229.3.29"
+	}
+}
+
+219517 = {
+	name="Geza"
+	dynasty=708
+	martial=8
+	diplomacy=7
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="inbred"
+	trait="flamboyant_schemer"
+	father=219510
+	mother=222573
+	1150.1.2 = {
+		birth="1150.1.2"
+	}
+	1200.1.2 = {
+		death="1200.1.2"
+	}
+}
+
+219518 = {
+	name="Helena"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="martial_cleric"
+	father=219510
+	mother=222573
+	1158.1.2 = {
+		birth="1158.1.2"
+	}
+	1208.1.2 = {
+		death="1208.1.2"
+	}
+}
+
+219519 = {
+	name="Margit"
+	female=yes
+	dynasty=708
+	martial=6
+	diplomacy=7
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="gluttonous"
+	trait="cynical"
+	trait="scholarly_theologian"
+	father=219510
+	mother=222573
+	1162.1.2 = {
+		birth="1162.1.2"
+	}
+	1212.1.2 = {
+		death="1212.1.2"
+	}
+}
+
+219525 = {
+	name="Erzsebet"
+	female=yes
+	dynasty=708
+	martial=7
+	diplomacy=7
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="cynical"
+	trait="underhanded_rogue"
+	father=480
+	mother=98008
+	1094.1.2 = {
+		birth="1094.1.2"
+	}
+	1153.1.2 = {
+		death="1153.1.2"
+	}
+}
+
+219530 = {
+	name="Béla"
+	# AKA: Bela
+	dynasty=708
+	martial=4
+	diplomacy=8
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="cynical"
+	trait="maimed"
+	trait="scholarly_theologian"
+	father=219531
+	mother=219532
+	1109.1.2 = {
+		birth="1109.1.2"
+	}
+	1127.4.28 = {
+		add_spouse=218511
+	}
+	1131.4.2 = {
+	capital=k_hungary
+	}
+	1141.2.13 = {
+		death="1141.2.13"
+	}
+}
+
+219531 = {
+	name="Almos"
+	dynasty=708
+	martial=5
+	diplomacy=5
+	intrigue=8
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="wroth"
+	trait="charismatic_negotiator"
+	father=472
+	mother=479
+	1074.1.2 = {
+		birth="1074.1.2"
+	}
+	1104.8.21 = {
+		add_spouse=219532
+	}
+	1129.1.3 = {
+		death="1129.1.3"
+	}
+}
+
+219533 = {
+	name="Adelaida"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=4
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="scholarly_theologian"
+	father=219531
+	mother=219532
+	1105.1.2 = {
+		birth="1105.1.2"
+	}
+	1141.1.14 = {
+		death="1141.1.14"
+	}
+}
+
+219550 = {
+	name="Andras"
+	dynasty=180
+	martial=8
+	diplomacy=4
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="martial_cleric"
+	1154.1.2 = {
+		birth="1154.1.2"
+	}
+	1204.1.2 = {
+		death="1204.1.2"
+	}
+}
+
+231060 = {
+	name="Eirene"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=8
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="humble"
+	trait="scholarly_theologian"
+	father=474
+	mother=1399
+	1088.1.2 = {
+		birth="1088.1.2"
+	}
+	1134.1.14 = {
+		death="1134.1.14"
+	}
+}
+
+231065 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=708
+	martial=8
+	diplomacy=5
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="just"
+	trait="proud"
+	trait="skilled_tactician"
+	father=480
+	mother=98008
+	1101.1.2 = {
+		birth="1101.1.2"
+	}
+	1116.2.3 = {
+		capital=k_hungary
+	}
+	1120.1.2 = {
+		add_spouse=98013
+	}
+	1131.4.2 = {
+		death="1131.4.2"
+	}
+}
+
+232553 = {
+	name="Borisz-Konrád"
+	# AKA: Borisz
+	dynasty=708
+	martial=5
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="bastard"
+	trait="gregarious"
+	trait="greedy"
+	trait="misguided_warrior"
+	father=480
+	mother=98018
+	1113.1.2 = {
+		birth="1113.1.2"
+	}
+	1130.1.2 = {
+		add_spouse=232554
+	}
+	1156.1.2 = {
+		death="1156.1.2"
+	}
+}
+
+41200 = {
+	name="Mária"
+	# AKA: Maria
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="thrifty_clerk"
+	father=470
+	mother=763
+	1050.1.1 = {
+		birth="1050.1.1"
+	}
+	1066.1.1 = {
+	employer=474
+	}
+	1103.1.1 = {
+		death="1103.1.1"
+	}
+}
+
+41201 = {
+	name="Lanka"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	father=470
+	mother=763
+	1045.1.1 = {
+		birth="1045.1.1"
+	}
+	1095.6.18 = {
+		death="1095.6.18"
+	}
+}
+
+4358 = {
+	name="Álmos"
+	# AKA: Almos
+	dynasty=101563
+	martial=6
+	diplomacy=5
+	intrigue=8
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="just"
+	trait="fortune_builder"
+	father=20372
+	mother=4444
+	1049.1.1 = {
+		birth="1049.1.1"
+	}
+	1114.1.1 = {
+		death="1114.1.1"
+	}
+}
+
+4362 = {
+	name="Amália"
+	# AKA: Amalia
+	female=yes
+	dynasty=19030
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="elusive_shadow"
+	1039.1.1 = {
+		birth="1039.1.1"
+	}
+	1090.1.1 = {
+		death="1090.1.1"
+	}
+}
+
+4363 = {
+	name="Zsófia"
+	# AKA: Zsofia
+	female=yes
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="charismatic_negotiator"
+	1040.1.1 = {
+		birth="1040.1.1"
+	}
+	1095.1.1 = {
+		death="1095.1.1"
+	}
+}
+
+4365 = {
+	name="Jolán"
+	# AKA: Jolan
+	female=yes
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	1025.1.1 = {
+		birth="1025.1.1"
+	}
+	1078.1.1 = {
+		death="1078.1.1"
+	}
+}
+
+4366 = {
+	name="Mária"
+	# AKA: Maria
+	female=yes
+	dynasty=101565
+	martial=4
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="thrifty_clerk"
+	father=20365
+	mother=4365
+	1049.1.1 = {
+		birth="1049.1.1"
+	}
+	1109.1.1 = {
+		death="1109.1.1"
+	}
+}
+
+4371 = {
+	name="Domoszló"
+	# AKA: Domoszlo
+	dynasty=19000
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="honest"
+	trait="tough_soldier"
+	father=20371
+	mother=499
+	1022.1.1 = {
+		birth="1022.1.1"
+	}
+	1050.1.1 = {
+		add_spouse=4443
+	}
+	1070.1.1 = {
+		death="1070.1.1"
+	}
+}
+
+4373 = {
+	name="Orsolya"
+	female=yes
+	dynasty=19000
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=4371
+	mother=4443
+	1051.1.1 = {
+		birth="1051.1.1"
+	}
+	1109.1.1 = {
+		death="1109.1.1"
+	}
+}
+
+4374 = {
+	name="Ernyei"
+	dynasty=101572
+	martial=7
+	diplomacy=7
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="ambitious"
+	trait="mastermind_theologian"
+	1021.1.1 = {
+		birth="1021.1.1"
+	}
+	1063.12.1 = {
+		effect = {
+			give_job_title=job_spiritual
+		}
+	}
+	1080.1.1 = {
+		death="1080.1.1"
+	}
+}
+
+4375 = {
+	name="Vid"
+	dynasty=19052
+	martial=5
+	diplomacy=4
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="martial_cleric"
+	father=20378
+	mother=4363
+	1059.1.1 = {
+		birth="1059.1.1"
+	}
+	1093.1.1 = {
+		death="1093.1.1"
+	}
+}
+
+4376 = {
+	name="Márton"
+	# AKA: Marton
+	dynasty=19052
+	martial=5
+	diplomacy=5
+	intrigue=3
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=20378
+	mother=4363
+	1062.1.1 = {
+		birth="1062.1.1"
+	}
+	1125.1.1 = {
+		death="1125.1.1"
+	}
+}
+
+4377 = {
+	name="Lothár"
+	dynasty=19052
+	martial=6
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="bastard"
+	father=20378
+	mother=4363
+	1064.1.1 = {
+		birth="1064.1.1"
+	}
+	1115.1.1 = {
+		death="1115.1.1"
+	}
+}
+
+4378 = {
+	name="Doboka"
+	dynasty=101566
+	martial=7
+	diplomacy=8
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="gluttonous"
+	trait="brave"
+	trait="tough_soldier"
+	959.1.1 = {
+		birth="959.1.1"
+	}
+	1012.1.1 = {
+		death="1012.1.1"
+	}
+}
+
+4379 = {
+	name="Csanád"
+	dynasty=101566
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="chaste"
+	trait="skilled_tactician"
+	father=4378
+	988.1.1 = {
+		birth="988.1.1"
+	}
+	1031.1.1 = {
+		death="1031.1.1"
+	}
+}
+
+4383 = {
+	name="Csömör"
+	dynasty=101566
+	martial=5
+	diplomacy=6
+	intrigue=3
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="cynical"
+	trait="scholarly_theologian"
+	father=4379
+	1019.1.1 = {
+		birth="1019.1.1"
+	}
+	1057.1.1 = {
+		death="1057.1.1"
+	}
+}
+
+4384 = {
+	name="Erzsébet"
+	female=yes
+	martial=7
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="amateurish_plotter"
+	1031.1.1 = {
+		birth="1031.1.1"
+	}
+	1094.1.1 = {
+		death="1094.1.1"
+	}
+}
+
+4385 = {
+	name="Imre"
+	dynasty=101566
+	martial=4
+	diplomacy=5
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="slothful"
+	trait="indulgent_wastrel"
+	father=4383
+	1042.1.1 = {
+		birth="1042.1.1"
+	}
+	1098.1.1 = {
+		death="1098.1.1"
+	}
+}
+
+4386 = {
+	name="Pongrácz"
+	dynasty=101566
+	martial=6
+	diplomacy=5
+	intrigue=4
+	stewardship=2
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=20364
+	mother=4384
+	1055.1.1 = {
+		birth="1055.1.1"
+	}
+	1098.1.1 = {
+		death="1098.1.1"
+	}
+}
+
+4387 = {
+	name="Gyula"
+	dynasty=101566
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="martial_cleric"
+	father=20364
+	mother=4384
+	1056.1.1 = {
+		birth="1056.1.1"
+	}
+	1117.1.1 = {
+		death="1117.1.1"
+	}
+}
+
+4388 = {
+	name="Margit"
+	female=yes
+	dynasty=19052
+	martial=4
+	diplomacy=6
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="humble"
+	trait="flamboyant_schemer"
+	father=20363
+	mother=491
+	1037.1.1 = {
+		birth="1037.1.1"
+	}
+	1075.1.1 = {
+		death="1075.1.1"
+	}
+}
+
+4389 = {
+	name="Gizella"
+	dynasty=19019
+	female=yes
+	martial=6
+	diplomacy=5
+	intrigue=5
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="flamboyant_schemer"
+	1017.1.1 = {
+		birth="1017.1.1"
+	}
+	1063.1.1 = {
+		death="1063.1.1"
+	}
+}
+
+4397 = {
+	name="Imre"
+	dynasty=101568
+	martial=8
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="kind"
+	trait="naive_appeaser"
+	father=20360
+	mother=4389
+	1048.1.1 = {
+		birth="1048.1.1"
+	}
+	1102.1.1 = {
+		death="1102.1.1"
+	}
+}
+
+4398 = {
+	name="Judit"
+	female=yes
+	dynasty=101568
+	martial=5
+	diplomacy=6
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="thrifty_clerk"
+	father=20360
+	mother=4389
+	1048.1.1 = {
+		birth="1048.1.1"
+	}
+	1105.1.1 = {
+		death="1105.1.1"
+	}
+}
+
+4400 = {
+	name="Tamás"
+	dynasty=101569
+	martial=3
+	diplomacy=5
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="martial_cleric"
+	father=4399
+	1045.1.1 = {
+		birth="1045.1.1"
+	}
+	1100.1.1 = {
+		death="1100.1.1"
+	}
+}
+
+4401 = {
+	name="Ipoly"
+	dynasty=19052
+	martial=7
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="tough_soldier"
+	father=20362
+	1033.1.1 = {
+		birth="1033.1.1"
+	}
+	1057.1.1 = {
+		add_spouse=4404
+	}
+	1090.1.1 = {
+		death="1090.1.1"
+	}
+}
+
+4402 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19052
+	martial=3
+	diplomacy=6
+	intrigue=7
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="arbitrary"
+	trait="martial_cleric"
+	father=20362
+	1035.1.1 = {
+		birth="1035.1.1"
+	}
+	1108.1.1 = {
+		death="1108.1.1"
+	}
+}
+
+4404 = {
+	name="Ilona"
+	female=yes
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="grey_eminence"
+	1036.1.1 = {
+		birth="1036.1.1"
+	}
+	1085.1.1 = {
+		death="1085.1.1"
+	}
+}
+
+4405 = {
+	name="Gertrúd"
+	# AKA: Gertrud
+	female=yes
+	dynasty=19052
+	martial=8
+	diplomacy=6
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	father=4406
+	mother=4362
+	1059.1.1 = {
+		birth="1059.1.1"
+	}
+	1120.1.1 = {
+		death="1120.1.1"
+	}
+}
+
+4406 = {
+	name="Bény"
+	# AKA: Beny
+	dynasty=19052
+	martial=6
+	diplomacy=6
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="arbitrary"
+	trait="fortune_builder"
+	father=20362
+	1039.1.1 = {
+		birth="1039.1.1"
+	}
+	1055.1.1 = {
+		add_spouse=4362
+	}
+	1087.1.1 = {
+		death="1087.1.1"
+	}
+}
+
+4409 = {
+	name="Miska"
+	dynasty=101570
+	martial=8
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="tough_soldier"
+	father=4408
+	1001.1.1 = {
+		birth="1001.1.1"
+	}
+	1053.1.1 = {
+		death="1053.1.1"
+	}
+}
+
+4410 = {
+	name="Kupán"
+	# AKA: Kupan
+	dynasty=101570
+	martial=4
+	diplomacy=6
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	trait="proud"
+	father=4409
+	1034.1.1 = {
+		birth="1034.1.1"
+	}
+	1057.1.1 = {
+		add_spouse=4415
+	}
+	1084.1.2 = {
+		death="1084.1.2"
+	}
+}
+
+4411 = {
+	name="Katalin"
+	female=yes
+	dynasty=12003
+	martial=8
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="underhanded_rogue"
+	1028.1.1 = {
+		birth="1028.1.1"
+	}
+	1089.1.1 = {
+		death="1089.1.1"
+	}
+}
+
+4412 = {
+	name="Bátor Obus"
+	# AKA: Bator Obus
+	dynasty=101570
+	martial=8
+	diplomacy=4
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="tough_soldier"
+	father=1621
+	mother=4411
+	1046.1.1 = {
+		birth="1046.1.1"
+	}
+	1095.1.1 = {
+		death="1095.1.1"
+	}
+}
+
+4413 = {
+	name="Anna"
+	female=yes
+	dynasty=101570
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="charismatic_negotiator"
+	father=1621
+	mother=4411
+	1048.1.1 = {
+		birth="1048.1.1"
+	}
+	1109.1.1 = {
+		death="1109.1.1"
+	}
+}
+
+4414 = {
+	name="Margit"
+	female=yes
+	dynasty=101570
+	martial=2
+	diplomacy=5
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="slothful"
+	trait="indulgent_wastrel"
+	father=1621
+	mother=4411
+	1050.1.1 = {
+		birth="1050.1.1"
+	}
+	1111.1.1 = {
+		death="1111.1.1"
+	}
+}
+
+4425 = {
+	name="Katalin"
+	female=yes
+	dynasty=101570
+	martial=4
+	diplomacy=4
+	intrigue=3
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=4410
+	mother=4415
+	1060.1.1 = {
+		birth="1060.1.1"
+	}
+	1118.1.1 = {
+		death="1118.1.1"
+	}
+}
+
+4431 = {
+	name="Hartvik"
+	dynasty=19061
+	martial=4
+	diplomacy=7
+	intrigue=8
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="zealous"
+	trait="scholarly_theologian"
+	1033.1.1 = {
+		birth="1033.1.1"
+	}
+	1063.12.1 = {
+		effect = {
+			give_job_title=job_spiritual
+		}
+	}
+	1111.1.1 = {
+		death="1111.1.1"
+	}
+}
+
+4432 = {
+	name="Elõd"
+	dynasty=19010
+	martial=7
+	diplomacy=6
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="fortune_builder"
+	father=20356
+	mother=4434
+	1046.1.1 = {
+		birth="1046.1.1"
+	}
+	1098.1.1 = {
+		death="1098.1.1"
+	}
+}
+
+4433 = {
+	name="Szabolcs"
+	dynasty=19010
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="envious"
+	trait="underhanded_rogue"
+	father=20356
+	mother=4434
+	1048.1.1 = {
+		birth="1048.1.1"
+	}
+	1105.1.1 = {
+		death="1105.1.1"
+	}
+}
+
+4434 = {
+	name="Anna"
+	female=yes
+	martial=6
+	diplomacy=7
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="cynical"
+	trait="martial_cleric"
+	1024.1.1 = {
+		birth="1024.1.1"
+	}
+	1078.1.1 = {
+		death="1078.1.1"
+	}
+}
+
+4435 = {
+	name="Antal"
+	dynasty=101571
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="greedy"
+	trait="misguided_warrior"
+	father=4437
+	1042.1.1 = {
+		birth="1042.1.1"
+	}
+	1065.1.1 = {
+		add_spouse=4436
+	}
+	1087.1.1 = {
+		death="1087.1.1"
+	}
+}
+
+4436 = {
+	name="Borbála"
+	dynasty=19010
+	female=yes
+	martial=4
+	diplomacy=6
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="honest"
+	trait="naive_appeaser"
+	father=20356
+	mother=4434
+	1047.1.1 = {
+		birth="1047.1.1"
+	}
+	1107.1.1 = {
+		death="1107.1.1"
+	}
+}
+
+4437 = {
+	name="Ete"
+	dynasty=101571
+	martial=7
+	diplomacy=7
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="underhanded_rogue"
+	1018.1.1 = {
+		birth="1018.1.1"
+	}
+	1061.1.1 = {
+		death="1061.1.1"
+	}
+}
+
+4438 = {
+	name="Gergely"
+	dynasty=101571
+	martial=8
+	diplomacy=4
+	intrigue=3
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="amateurish_plotter"
+	father=4437
+	1049.1.1 = {
+		birth="1049.1.1"
+	}
+	1065.1.2 = {
+		add_spouse=4439
+	}
+	1122.1.1 = {
+		death="1122.1.1"
+	}
+}
+
+4439 = {
+	name="Ildikó"
+	# AKA: Ildiko
+	female=yes
+	martial=7
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="flamboyant_schemer"
+	1050.1.1 = {
+		birth="1050.1.1"
+	}
+	1111.1.1 = {
+		death="1111.1.1"
+	}
+}
+
+4440 = {
+	name="Péter"
+	dynasty=101571
+	martial=6
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=4435
+	mother=4436
+	1066.1.1 = {
+		birth="1066.1.1"
+	}
+	1115.1.1 = {
+		death="1115.1.1"
+	}
+}
+
+4441 = {
+	name="Sugárka"
+	# AKA: Sugarka
+	female=yes
+	dynasty=101565
+	martial=4
+	diplomacy=3
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="arbitrary"
+	trait="temperate"
+	trait="thrifty_clerk"
+	father=20365
+	mother=4365
+	1042.1.1 = {
+		birth="1042.1.1"
+	}
+	1099.1.1 = {
+		death="1099.1.1"
+	}
+}
+
+4442 = {
+	name="Zila"
+	dynasty=101565
+	female=yes
+	martial=5
+	diplomacy=9
+	intrigue=4
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="detached_priest"
+	father=20365
+	mother=4365
+	1044.1.1 = {
+		birth="1044.1.1"
+	}
+	1106.1.1 = {
+		death="1106.1.1"
+	}
+}
+
+4443 = {
+	name="Skolasztika"
+	female=yes
+	dynasty=19001
+	martial=5
+	diplomacy=3
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="zealous"
+	trait="thrifty_clerk"
+	1031.1.1 = {
+		birth="1031.1.1"
+	}
+	1089.1.1 = {
+		death="1089.1.1"
+	}
+}
+
+4444 = {
+	name="Etel"
+	female=yes
+	dynasty=19003
+	martial=7
+	diplomacy=5
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="greedy"
+	trait="cynical"
+	trait="amateurish_plotter"
+	1031.1.1 = {
+		birth="1031.1.1"
+	}
+	1095.1.1 = {
+		death="1095.1.1"
+	}
+}
+
+460 = {
+	name="Taksony"
+	dynasty=708
+	martial=5
+	diplomacy=7
+	intrigue=7
+	stewardship=5
+	religion="tengri_pagan"
+	culture="hungarian"
+	trait="proud"
+	trait="underhanded_rogue"
+	father=159135
+	931.1.1 = {
+		birth="931.1.1"
+	}
+	947.1.1 = {
+		add_spouse=483
+	}
+	972.1.1 = {
+		death="972.1.1"
+	}
+}
+
+461711 = {
+	name="Maria"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=4
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="flamboyant_schemer"
+	father=98004
+	mother=98042
+	1257.1.2 = {
+		birth="1257.1.2"
+	}
+	1323.1.26 = {
+		death="1323.1.26"
+	}
+}
+
+462 = {
+	name="Mihály"
+	# AKA: Mihaly
+	dynasty=708
+	martial=5
+	diplomacy=4
+	intrigue=8
+	stewardship=5
+	religion="tengri_pagan"
+	culture="hungarian"
+	trait="envious"
+	trait="skilled_tactician"
+	father=460
+	mother=483
+	948.1.1 = {
+		birth="948.1.1"
+	}
+	970.1.1 = {
+		add_spouse=759
+	}
+	978.1.1 = {
+		death="978.1.1"
+	}
+}
+
+463 = {
+	name="Judit"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=6
+	intrigue=8
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="flamboyant_schemer"
+	father=464
+	mother=753
+	969.1.1 = {
+		birth="969.1.1"
+	}
+	987.1.1 = {
+		death="987.1.1"
+	}
+}
+
+464 = {
+	name="Géza"
+	# AKA: Geza
+	dynasty=708
+	martial=5
+	diplomacy=8
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="cynical"
+	trait="tough_soldier"
+	father=460
+	mother=483
+	945.1.1 = {
+		birth="945.1.1"
+	}
+	967.1.1 = {
+		add_spouse=753
+	}
+	975.1.1 = {
+	remove_spouse=753
+	}
+	985.1.1 = {
+		add_spouse=759
+	}
+	997.2.1 = {
+		death="997.2.1"
+	}
+}
+
+466 = {
+	name="Vászoly"
+	# AKA: Vaszoly
+	dynasty=708
+	martial=6
+	diplomacy=4
+	intrigue=4
+	stewardship=8
+	religion="tengri_pagan"
+	culture="hungarian"
+	trait="wroth"
+	trait="tough_soldier"
+	father=462
+	mother=759
+	976.1.1 = {
+		birth="976.1.1"
+	}
+	1037.1.1 = {
+		death="1037.1.1"
+	}
+}
+
+468 = {
+	name="András"
+	# AKA: Andras
+	dynasty=708
+	martial=7
+	diplomacy=4
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="patient"
+	trait="charismatic_negotiator"
+	father=466
+	mother=484
+	1014.1.1 = {
+		birth="1014.1.1"
+	}
+	1039.1.1 = {
+		add_spouse=637
+	}
+	1060.10.1 = {
+		death="1060.10.1"
+	}
+}
+
+469 = {
+	name="Zsófia"
+	# AKA: Zsofia
+	female=yes
+	dynasty=708
+	martial=3
+	diplomacy=6
+	intrigue=6
+	stewardship=6
+	trait="bastard"
+	religion="catholic"
+	culture="hungarian"
+	father=470
+	1062.1.1 = {
+		birth="1062.1.1"
+	}
+	1066.1.1 = {
+	employer=472
+	}
+	1116.1.1 = {
+		death="1116.1.1"
+	}
+}
+
+470 = {
+	name="Béla"
+	# AKA: Bela
+	dynasty=708
+	martial=7
+	diplomacy=5
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="diligent"
+	trait="brave"
+	trait="skilled_tactician"
+	father=466
+	mother=484
+	1016.1.1 = {
+		birth="1016.1.1"
+	}
+	1039.1.1 = {
+		add_spouse=763
+	}
+	1063.12.1 = {
+		death="1063.12.1"
+	}
+}
+
+470030 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19063
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="proud"
+	trait="tough_soldier"
+	father=470031
+	1310.1.1 = {
+		birth="1310.1.1"
+	}
+	1335.1.2 = {
+		add_spouse=470032
+	}
+	1360.1.1 = {
+		death="1360.1.1"
+	}
+}
+
+470031 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19063
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="tough_soldier"
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1315.1.1 = {
+		death="1315.1.1"
+	}
+}
+
+470032 = {
+	name="Katarina"
+	female=yes
+	martial=4
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="humble"
+	trait="naive_appeaser"
+	1315.1.1 = {
+		birth="1315.1.1"
+	}
+	1365.1.1 = {
+		death="1365.1.1"
+	}
+}
+
+470040 = {
+	name="Tamás"
+	dynasty=19043
+	martial=7
+	diplomacy=5
+	intrigue=7
+	stewardship=9
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="charitable"
+	trait="tough_soldier"
+	father=470049
+	1285.1.2 = {
+		birth="1285.1.2"
+	}
+	1317.1.2 = {
+		add_spouse=470041
+	}
+	1328.1.2 = {
+		add_spouse=470042
+	}
+	1344.1.1 = {
+		death="1344.1.1"
+	}
+}
+
+470041 = {
+	name="Erzsébet" 
+	#AKA Erzsebet Visontai
+	female=yes
+	martial=5
+	diplomacy=5
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	1299.1.2 = {
+		birth="1299.1.2"
+	}
+	1327.1.2 = {
+		death="1327.1.2"
+	}
+}
+
+470043 = {
+	name="Kónya"
+	# AKA: Konya
+	dynasty=19043
+	martial=5
+	diplomacy=4
+	intrigue=2
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="proud"
+	trait="tough_soldier"
+	father=470040
+	mother=470041
+	1318.1.2 = {
+		birth="1318.1.2"
+	}
+	1368.1.2 = {
+		death="1368.1.2"
+	}
+}
+
+470044 = {
+	name="Mihály"
+	# AKA: Mihaly
+	dynasty=19043
+	martial=5
+	diplomacy=6
+	intrigue=3
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="zealous"
+	trait="mastermind_theologian"
+	father=470040
+	mother=470041
+	1319.1.2 = {
+		birth="1319.1.2"
+	}
+	1369.1.2 = {
+		death="1369.1.2"
+	}
+}
+
+470045 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19043
+	martial=3
+	diplomacy=4
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="tough_soldier"
+	father=470040
+	mother=470041
+	1321.1.2 = {
+		birth="1321.1.2"
+	}
+	1371.1.2 = {
+		death="1371.1.2"
+	}
+}
+
+470046 = {
+	name="Gáspár"
+	# AKA: Gaspar
+	dynasty=19043
+	martial=3
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470040
+	mother=470042
+	1329.1.2 = {
+		birth="1329.1.2"
+	}
+	1379.1.2 = {
+		death="1379.1.2"
+	}
+}
+
+470047 = {
+	name="Anna"
+	female=yes
+	dynasty=19043
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=470040
+	mother=470042
+	1332.1.2 = {
+		birth="1332.1.2"
+	}
+	1382.1.2 = {
+		death="1382.1.2"
+	}
+}
+
+470048 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=19043
+	martial=5
+	diplomacy=6
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	father=470040
+	mother=470042
+	1335.1.2 = {
+		birth="1335.1.2"
+	}
+	1385.1.2 = {
+		death="1385.1.2"
+	}
+}
+
+470049 = {
+	name="Farkas"
+	dynasty=19043
+	martial=4
+	diplomacy=4
+	intrigue=7
+	stewardship=10
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="charitable"
+	trait="flamboyant_schemer"
+	1257.1.2 = {
+		birth="1257.1.2"
+	}
+	1305.1.2 = {
+		death="1305.1.2"
+	}
+}
+
+470050 = {
+	name="Péter"
+	dynasty=19043
+	martial=7
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="humble"
+	trait="tough_soldier"
+	father=470049
+	1292.1.2 = {
+		birth="1292.1.2"
+	}
+	1342.1.2 = {
+		death="1342.1.2"
+	}
+}
+
+470051 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19043
+	martial=2
+	diplomacy=5
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="proud"
+	trait="thrifty_clerk"
+	father=470050
+	1316.1.2 = {
+		birth="1316.1.2"
+	}
+	1366.1.2 = {
+		death="1366.1.2"
+	}
+}
+
+470052 = {
+	name="Tamás"
+	dynasty=19043
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="tough_soldier"
+	father=470050
+	1318.1.2 = {
+		birth="1318.1.2"
+	}
+	1368.1.2 = {
+		death="1368.1.2"
+	}
+}
+
+470053 = {
+	name="Farkas"
+	dynasty=19043
+	martial=5
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="slothful"
+	trait="tough_soldier"
+	father=470050
+	1320.1.2 = {
+		birth="1320.1.2"
+	}
+	1370.1.2 = {
+		death="1370.1.2"
+	}
+}
+
+470060 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=19056
+	martial=5
+	diplomacy=4
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="slothful"
+	trait="tough_soldier"
+	1260.1.2 = {
+		birth="1260.1.2"
+	}
+	1286.1.2 = {
+		add_spouse=470061
+	}
+	1320.1.2 = {
+		death="1320.1.2"
+	}
+}
+
+470061 = {
+	name="Margit"
+	# AKA: Margit Pelejtei
+	female=yes
+	martial=4
+	diplomacy=4
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="charitable"
+	trait="flamboyant_schemer"
+	1270.1.2 = {
+		birth="1270.1.2"
+	}
+	1333.1.2 = {
+		death="1333.1.2"
+	}
+}
+
+470062 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19056
+	martial=7
+	diplomacy=4
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="patient"
+	trait="tough_soldier"
+	father=470060
+	mother=470061
+	1308.1.2 = {
+		birth="1308.1.2"
+	}
+	1330.1.2 = {
+		add_spouse=470063
+	}
+	1358.1.2 = {
+		death="1358.1.2"
+	}
+}
+
+470063 = {
+	name="Katalin"
+	female=yes
+	martial=6
+	diplomacy=4
+	intrigue=7
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="harelip"
+	trait="thrifty_clerk"
+	1311.1.2 = {
+		birth="1311.1.2"
+	}
+	1361.1.2 = {
+		death="1361.1.2"
+	}
+}
+
+470064 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19056
+	martial=5
+	diplomacy=4
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	father=470062
+	mother=470063
+	1333.1.2 = {
+		birth="1333.1.2"
+	}
+	1383.1.2 = {
+		death="1383.1.2"
+	}
+}
+
+470065 = {
+	name="Domokos"
+	dynasty=19056
+	martial=6
+	diplomacy=7
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	father=470062
+	mother=470063
+	1336.1.2 = {
+		birth="1336.1.2"
+	}
+	1386.1.2 = {
+		death="1386.1.2"
+	}
+}
+
+470070 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19057
+	martial=7
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="just"
+	trait="tough_soldier"
+	father=470071
+	mother=470073
+	1299.1.2 = {
+		birth="1299.1.2"
+	}
+	1321.1.2 = {
+		add_spouse=470074
+	}
+	1349.1.2 = {
+		death="1349.1.2"
+	}
+}
+
+470071 = {
+	name="Miklós"
+	dynasty=19057
+	martial=7
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="just"
+	trait="tough_soldier"
+	father=93755
+	1258.1.1 = {
+		birth="1258.1.1"
+	}
+	1288.1.1 = {
+		add_spouse=470072
+	}
+	1297.1.1 = {
+		add_spouse=470073
+	}
+	1320.1.1 = {
+		death="1320.1.1"
+	}
+}
+
+470072 = {
+	name="Erzsébet" 
+	#AKA Erzsebet de Daro
+	female=yes
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="thrifty_clerk"
+	1272.1.2 = {
+		birth="1272.1.2"
+	}
+	1296.1.2 = {
+		death="1296.1.2"
+	}
+}
+
+470073 = {
+	name="Erzsébet" 
+	#AKA Erzsebet Kaplyon
+	female=yes
+	martial=7
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="arbitrary"
+	trait="charitable"
+	trait="naive_appeaser"
+	1280.1.2 = {
+		birth="1280.1.2"
+	}
+	1330.1.2 = {
+		death="1330.1.2"
+	}
+}
+
+470074 = {
+	name="Anna"
+	female=yes
+	dynasty=19051
+	martial=6
+	diplomacy=5
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="lustful"
+	trait="flamboyant_schemer"
+	1302.1.2 = {
+		birth="1302.1.2"
+	}
+	1352.1.2 = {
+		death="1352.1.2"
+	}
+}
+
+470075 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19057
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="martial_cleric"
+	father=470070
+	mother=470074
+	1323.1.2 = {
+		birth="1323.1.2"
+	}
+	1373.1.2 = {
+		death="1373.1.2"
+	}
+}
+
+470076 = {
+	name="Móricz"
+	# AKA: Moricz
+	dynasty=19057
+	martial=7
+	diplomacy=7
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="slothful"
+	trait="thrifty_clerk"
+	father=470071
+	mother=470072
+	1295.1.2 = {
+		birth="1295.1.2"
+	}
+	1326.1.2 = {
+		add_spouse=470078
+	}
+	1345.1.2 = {
+		death="1345.1.2"
+	}
+}
+
+470077 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19057
+	martial=2
+	diplomacy=2
+	intrigue=8
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="patient"
+	trait="elusive_shadow"
+	father=470071
+	mother=470073
+	1300.1.2 = {
+		birth="1300.1.2"
+	}
+	1350.1.2 = {
+		death="1350.1.2"
+	}
+}
+
+470078 = {
+	name="Skolasztika Atyinai"
+	# AKA: Skolasztika Atyinai
+	female=yes
+	martial=5
+	diplomacy=4
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="gluttonous"
+	trait="midas_touched"
+	1300.1.2 = {
+		birth="1300.1.2"
+	}
+	1350.1.2 = {
+		death="1350.1.2"
+	}
+}
+
+470079 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19057
+	martial=6
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470076
+	mother=470078
+	1332.1.2 = {
+		birth="1332.1.2"
+	}
+	1382.1.2 = {
+		death="1382.1.2"
+	}
+}
+
+470080 = {
+	name="Anna"
+	female=yes
+	dynasty=19057
+	martial=5
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	father=470076
+	mother=470078
+	1335.1.2 = {
+		birth="1335.1.2"
+	}
+	1385.1.2 = {
+		death="1385.1.2"
+	}
+}
+
+470090 = {
+	name="Osli"
+	dynasty=19058
+	martial=6
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	1180.1.1 = {
+		birth="1180.1.1"
+	}
+	1230.1.1 = {
+		death="1230.1.1"
+	}
+}
+
+470091 = {
+	name="Beled"
+	dynasty=19058
+	martial=6
+	diplomacy=5
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	father=470090
+	1210.1.2 = {
+		birth="1210.1.2"
+	}
+	1272.1.2 = {
+		death="1272.1.2"
+	}
+}
+
+470092 = {
+	name="Osli"
+	dynasty=19058
+	martial=7
+	diplomacy=7
+	intrigue=8
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	father=470090
+	1211.1.1 = {
+		birth="1211.1.1"
+	}
+	1266.1.1 = {
+		death="1266.1.1"
+	}
+}
+
+470093 = {
+	name="Támas Csornai" 
+	#AKA Tamas Csornai
+	dynasty=19058
+	martial=6
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470090
+	1213.1.2 = {
+		birth="1213.1.2"
+	}
+	1272.1.2 = {
+		death="1272.1.2"
+	}
+}
+
+470094 = {
+	name="Beled"
+	# AKA: Beled Viczay
+	dynasty=19059
+	martial=6
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="intricate_webweaver"
+	father=93651
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1291.1.1 = {
+		death="1291.1.1"
+	}
+}
+
+470095 = {
+	name="Miklós"
+	dynasty=19059
+	martial=6
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="intricate_webweaver"
+	father=470094
+	1254.1.1 = {
+		birth="1254.1.1"
+	}
+	1309.1.1 = {
+		death="1309.1.1"
+	}
+}
+
+470096 = {
+	name="Imre"
+	dynasty=19059
+	martial=7
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	father=470094
+	1257.1.1 = {
+		birth="1257.1.1"
+	}
+	1309.1.1 = {
+		death="1309.1.1"
+	}
+}
+
+470097 = {
+	name="János"
+	dynasty=19059
+	martial=6
+	diplomacy=4
+	intrigue=2
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=470094
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1310.1.1 = {
+		death="1310.1.1"
+	}
+}
+
+470098 = {
+	name="Beled"
+	dynasty=19059
+	martial=6
+	diplomacy=6
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="stutter"
+	trait="brave"
+	trait="tough_soldier"
+	father=470094
+	1266.1.1 = {
+		birth="1266.1.1"
+	}
+	1336.1.1 = {
+		death="1336.1.1"
+	}
+}
+
+470099 = {
+	name="János"
+	dynasty=19059
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470095
+	1284.1.1 = {
+		birth="1284.1.1"
+	}
+	1347.1.1 = {
+		death="1347.1.1"
+	}
+}
+
+470100 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19059
+	martial=1
+	diplomacy=2
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="harelip"
+	trait="arbitrary"
+	trait="detached_priest"
+	father=470099
+	1304.1.1 = {
+		birth="1304.1.1"
+	}
+	1347.1.1 = {
+		death="1347.1.1"
+	}
+}
+
+470101 = {
+	name="Tamás"
+	dynasty=19059
+	martial=7
+	diplomacy=7
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="gluttonous"
+	trait="tough_soldier"
+	father=470099
+	1306.1.1 = {
+		birth="1306.1.1"
+	}
+	1360.1.1 = {
+		death="1360.1.1"
+	}
+}
+
+470102 = {
+	name="Anna"
+	female=yes
+	dynasty=19059
+	martial=4
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="gluttonous"
+	trait="flamboyant_schemer"
+	father=470099
+	1315.1.1 = {
+		birth="1315.1.1"
+	}
+	1360.1.1 = {
+		death="1360.1.1"
+	}
+}
+
+470103 = {
+	name="Péter"
+	dynasty=19059
+	martial=7
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="craven"
+	trait="flamboyant_schemer"
+	father=470096
+	1305.1.2 = {
+		birth="1305.1.2"
+	}
+	1355.1.2 = {
+		death="1355.1.2"
+	}
+}
+
+470104 = {
+	name="Ilona"
+	female=yes
+	dynasty=19059
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="lustful"
+	trait="naive_appeaser"
+	father=470096
+	1309.1.2 = {
+		birth="1309.1.2"
+	}
+	1359.1.2 = {
+		death="1359.1.2"
+	}
+}
+
+470105 = {
+	name="Péter"
+	dynasty=19059
+	martial=7
+	diplomacy=4
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="brave"
+	trait="misguided_warrior"
+	father=470097
+	1305.1.1 = {
+		birth="1305.1.1"
+	}
+	1355.1.1 = {
+		death="1355.1.1"
+	}
+}
+
+470106 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19059
+	martial=4
+	diplomacy=4
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="charitable"
+	trait="tough_soldier"
+	father=470098
+	1306.1.2 = {
+		birth="1306.1.2"
+	}
+	1356.1.2 = {
+		death="1356.1.2"
+	}
+}
+
+470107 = {
+	name="Osli"
+	dynasty=19059
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470106
+	1325.1.2 = {
+		birth="1325.1.2"
+	}
+	1375.1.2 = {
+		death="1375.1.2"
+	}
+}
+
+470108 = {
+	name="Osli"
+	dynasty=19058
+	martial=7
+	diplomacy=7
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470092
+	1241.1.2 = {
+		birth="1241.1.2"
+	}
+	1270.1.2 = {
+		add_spouse=470109
+	}
+	1310.1.2 = {
+		death="1310.1.2"
+	}
+}
+
+470109 = {
+	name="Erzsébet" 
+	#AKA Erzsebet Nagymartoni
+	female=yes
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="detached_priest"
+	1261.1.2 = {
+		birth="1261.1.2"
+	}
+	1332.1.2 = {
+		death="1332.1.2"
+	}
+}
+
+470110 = {
+	name="Péter"
+	dynasty=19058
+	martial=7
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="bastard"
+	trait="detached_priest"
+	father=470108
+	1288.1.2 = {
+		birth="1288.1.2"
+	}
+	1338.1.2 = {
+		death="1338.1.2"
+	}
+}
+
+470111 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19058
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="patient"
+	trait="thrifty_clerk"
+	father=470108
+	mother=470109
+	1290.1.2 = {
+		birth="1290.1.2"
+	}
+	1340.1.2 = {
+		death="1340.1.2"
+	}
+}
+
+470112 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19058
+	martial=7
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="ill"
+	trait="temperate"
+	trait="tough_soldier"
+	father=470108
+	mother=470109
+	1291.1.2 = {
+		birth="1291.1.2"
+	}
+	1330.1.2 = {
+		add_spouse=470129
+	}
+	1341.1.2 = {
+		death="1341.1.2"
+	}
+}
+
+470113 = {
+	name="Domokos"
+	dynasty=19058
+	martial=5
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="just"
+	trait="tough_soldier"
+	father=470108
+	mother=470109
+	1285.1.2 = {
+		birth="1285.1.2"
+	}
+	1335.1.2 = {
+		death="1335.1.2"
+	}
+}
+
+470114 = {
+	name="Demeter"
+	# AKA: Demeter Bresztolci
+	dynasty=19058
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="brave"
+	trait="tough_soldier"
+	father=470113
+	1320.1.2 = {
+		birth="1320.1.2"
+	}
+	1370.1.2 = {
+		death="1370.1.2"
+	}
+}
+
+470115 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19058
+	martial=5
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470113
+	1329.1.2 = {
+		birth="1329.1.2"
+	}
+	1379.1.2 = {
+		death="1379.1.2"
+	}
+}
+
+470116 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19058
+	martial=5
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	father=470113
+	1333.1.2 = {
+		birth="1333.1.2"
+	}
+	1383.1.2 = {
+		death="1383.1.2"
+	}
+}
+
+470117 = {
+	name="Imre"
+	dynasty=19054
+	martial=6
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="misguided_warrior"
+	father=470093
+	1238.1.2 = {
+		birth="1238.1.2"
+	}
+	1305.1.2 = {
+		death="1305.1.2"
+	}
+}
+
+470118 = {
+	name="Lõrinc"
+	# AKA: Lorinc
+	dynasty=19054
+	martial=6
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="tough_soldier"
+	father=470117
+	1270.1.2 = {
+		birth="1270.1.2"
+	}
+	1310.1.2 = {
+		add_spouse=470121
+	}
+	1330.1.10 = {
+		death="1330.1.10"
+	}
+}
+
+470119 = {
+	name="Mihály"
+	# AKA: Mihaly
+	dynasty=19054
+	martial=2
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="tough_soldier"
+	father=470117
+	1298.1.2 = {
+		birth="1298.1.2"
+	}
+	1348.1.2 = {
+		death="1348.1.2"
+	}
+}
+
+470120 = {
+	name="Imre"
+	dynasty=19054
+	martial=5
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="proud"
+	trait="tough_soldier"
+	father=470117
+	1301.1.2 = {
+		birth="1301.1.2"
+	}
+	1351.1.2 = {
+		death="1351.1.2"
+	}
+}
+
+470121 = {
+	name="Katalin"
+	# AKA: Katalin Nagyamartoni
+	female=yes
+	martial=4
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="gluttonous"
+	trait="naive_appeaser"
+	1295.1.2 = {
+		birth="1295.1.2"
+	}
+	1345.1.2 = {
+		death="1345.1.2"
+	}
+}
+
+470122 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19054
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="just"
+	trait="tough_soldier"
+	father=470118
+	mother=470121
+	1310.1.2 = {
+		birth="1310.1.2"
+	}
+	1360.1.2 = {
+		death="1360.1.2"
+	}
+}
+
+470123 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19054
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="just"
+	trait="tough_soldier"
+	father=470118
+	mother=470121
+	1312.1.2 = {
+		birth="1312.1.2"
+	}
+	1362.1.2 = {
+		death="1362.1.2"
+	}
+}
+
+470124 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19054
+	martial=2
+	diplomacy=3
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="just"
+	trait="detached_priest"
+	father=470118
+	mother=470121
+	1315.1.2 = {
+		birth="1315.1.2"
+	}
+	1365.1.2 = {
+		death="1365.1.2"
+	}
+}
+
+470125 = {
+	name="Lõrinc"
+	# AKA: Lorinc
+	dynasty=19054
+	martial=7
+	diplomacy=1
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="ill"
+	trait="tough_soldier"
+	father=470118
+	mother=470121
+	1317.1.2 = {
+		birth="1317.1.2"
+	}
+	1367.1.2 = {
+		death="1367.1.2"
+	}
+}
+
+470126 = {
+	name="Benedek"
+	dynasty=19054
+	martial=2
+	diplomacy=5
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="arbitrary"
+	trait="thrifty_clerk"
+	father=470118
+	mother=470121
+	1320.1.2 = {
+		birth="1320.1.2"
+	}
+	1370.1.2 = {
+		death="1370.1.2"
+	}
+}
+
+470127 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19054
+	martial=8
+	diplomacy=8
+	intrigue=2
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470120
+	1331.1.2 = {
+		birth="1331.1.2"
+	}
+	1381.1.2 = {
+		death="1381.1.2"
+	}
+}
+
+470128 = {
+	name="Anna"
+	female=yes
+	martial=5
+	diplomacy=7
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="gluttonous"
+	trait="flamboyant_schemer"
+	1307.1.2 = {
+		birth="1307.1.2"
+	}
+	1357.1.2 = {
+		death="1357.1.2"
+	}
+}
+
+470129 = {
+	name="Erzsébet"
+	female=yes
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="temperate"
+	trait="naive_appeaser"
+	1309.1.2 = {
+		birth="1309.1.2"
+	}
+	1359.1.2 = {
+		death="1359.1.2"
+	}
+}
+
+470130 = {
+	name="Tamás"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=2
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=93662
+	1240.1.1 = {
+		birth="1240.1.1"
+	}
+	1299.1.1 = {
+		death="1299.1.1"
+	}
+}
+
+470131 = {
+	name="Lõrinc"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470130
+	1280.1.2 = {
+		birth="1280.1.2"
+	}
+	1315.1.10 = {
+		death="1315.1.10"
+	}
+}
+
+470132 = {
+	name="Miklós"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="tough_soldier"
+	father=470130
+	1289.1.2 = {
+		birth="1289.1.2"
+	}
+	1330.1.10 = {
+		death="1330.1.10"
+	}
+}
+
+470133 = {
+	name="Csanád"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="temperate"
+	trait="mastermind_theologian"
+	father=470130
+	1293.1.2 = {
+		birth="1293.1.2"
+	}
+	1343.1.2 = {
+		death="1343.1.2"
+	}
+}
+
+470134 = {
+	name="Pongrác"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="tough_soldier"
+	father=470130
+	1295.1.2 = {
+		birth="1295.1.2"
+	}
+	1330.1.10 = {
+		death="1330.1.10"
+	}
+}
+
+470135 = {
+	name="János"
+	dynasty=19045
+	martial=7
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="slothful"
+	trait="tough_soldier"
+	father=470131
+	1305.1.2 = {
+		birth="1305.1.2"
+	}
+	1355.1.2 = {
+		death="1355.1.2"
+	}
+}
+
+470136 = {
+	name="Tamás"
+	dynasty=19045
+	martial=5
+	diplomacy=4
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="proud"
+	trait="charismatic_negotiator"
+	father=470131
+	1309.1.2 = {
+		birth="1309.1.2"
+	}
+	1359.1.2 = {
+		death="1359.1.2"
+	}
+}
+
+470137 = {
+	name="István"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="detached_priest"
+	father=470132
+	1315.1.2 = {
+		birth="1315.1.2"
+	}
+	1365.1.2 = {
+		death="1365.1.2"
+	}
+}
+
+470138 = {
+	name="Demeter"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="ill"
+	trait="proud"
+	trait="tough_soldier"
+	father=470132
+	1318.1.2 = {
+		birth="1318.1.2"
+	}
+	1368.1.2 = {
+		death="1368.1.2"
+	}
+}
+
+470139 = {
+	name="György"
+	dynasty=19045
+	martial=2
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="diligent"
+	trait="flamboyant_schemer"
+	father=470132
+	1320.1.2 = {
+		birth="1320.1.2"
+	}
+	1370.1.2 = {
+		death="1370.1.2"
+	}
+}
+
+470140 = {
+	name="Miklós"
+	dynasty=19045
+	martial=2
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="diligent"
+	trait="thrifty_clerk"
+	father=470132
+	1322.1.2 = {
+		birth="1322.1.2"
+	}
+	1372.1.2 = {
+		death="1372.1.2"
+	}
+}
+
+470141 = {
+	name="Tamás"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="martial_cleric"
+	father=470134
+	1318.1.2 = {
+		birth="1318.1.2"
+	}
+	1368.1.2 = {
+		death="1368.1.2"
+	}
+}
+
+470142 = {
+	name="Dorottya"
+	female=yes
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="honest"
+	trait="thrifty_clerk"
+	1309.1.2 = {
+		birth="1309.1.2"
+	}
+	1359.1.2 = {
+		death="1359.1.2"
+	}
+}
+
+470150 = {
+	name="Henrik"
+	dynasty=19032
+	martial=7
+	diplomacy=6
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="tough_soldier"
+	father=93768
+	1270.1.1 = {
+		birth="1270.1.1"
+	}
+	1309.1.1 = {
+		death="1309.1.1"
+	}
+}
+
+470151 = {
+	name="Péter"
+	dynasty=19032
+	martial=5
+	diplomacy=7
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="humble"
+	trait="tough_soldier"
+	father=470150
+	1300.1.1 = {
+		birth="1300.1.1"
+	}
+	1326.1.1 = {
+		add_spouse=470152
+	}
+	1351.1.1 = {
+		death="1351.1.1"
+	}
+}
+
+470152 = {
+	name="Anna"
+	female = yes
+	dynasty=19007 #Blagai
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=2
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="envious"
+	trait="charismatic_negotiator"
+	father=32645
+	1310.1.1 = {
+		birth="1310.1.1"
+	}
+	1360.1.1 = {
+		death="1360.1.1"
+	}
+}
+
+470160 = {
+	name="István"
+	# AKA: Istvan Cseh
+	dynasty=19010
+	martial=7
+	diplomacy=7
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="brave"
+	trait="charitable"
+	trait="tough_soldier"
+	father=470161
+	mother=470162
+	1301.1.2 = {
+		birth="1301.1.2"
+	}
+	1333.1.2 = {
+		add_spouse=470164
+	}
+	1351.1.2 = {
+		death="1351.1.2"
+	}
+}
+
+470162 = {
+	name="Anna"
+	female=yes
+	dynasty=19010
+	martial=2
+	diplomacy=6
+	intrigue=2
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="thrifty_clerk"
+	father=470163
+	1275.1.2 = {
+		birth="1275.1.2"
+	}
+	1325.1.2 = {
+		death="1325.1.2"
+	}
+}
+
+470163 = {
+	name="Péter"
+	dynasty=19010
+	martial=5
+	diplomacy=4
+	intrigue=2
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="tough_soldier"
+	father=93683
+	1236.1.1 = {
+		birth="1236.1.1"
+	}
+	1278.1.1 = {
+		death="1278.1.1"
+	}
+}
+
+470164 = {
+	name="Anna"
+	female=yes
+	martial=2
+	diplomacy=2
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="greedy"
+	trait="flamboyant_schemer"
+	1309.1.2 = {
+		birth="1309.1.2"
+	}
+	1359.1.2 = {
+		death="1359.1.2"
+	}
+}
+
+470180 = {
+	name="Domokos"
+	dynasty=19060
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="envious"
+	trait="tough_soldier"
+	father=93718
+	1237.1.1 = {
+		birth="1237.1.1"
+	}
+	1280.1.1 = {
+		death="1280.1.1"
+	}
+}
+
+470181 = {
+	name="Doncs"
+	dynasty=19060
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="patient"
+	trait="lustful"
+	trait="tough_soldier"
+	father=470180
+	1275.1.1 = {
+		birth="1275.1.1"
+	}
+	1296.1.1 = {
+		add_spouse=470182
+	}
+	1345.7.22 = {
+		death="1345.7.22"
+	}
+}
+
+470182 = {
+	name="Klára"
+	# AKA: Klara
+	female=yes
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="charitable"
+	trait="flamboyant_schemer"
+	1280.1.2 = {
+		birth="1280.1.2"
+	}
+	1330.1.2 = {
+		death="1330.1.2"
+	}
+}
+
+470183 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=19060
+	martial=5
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="chaste"
+	trait="tough_soldier"
+	father=470181
+	mother=470182
+	1307.1.2 = {
+		birth="1307.1.2"
+	}
+	1357.1.2 = {
+		death="1357.1.2"
+	}
+}
+
+470184 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19060
+	martial=6
+	diplomacy=2
+	intrigue=2
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="misguided_warrior"
+	father=470181
+	mother=470182
+	1310.1.2 = {
+		birth="1310.1.2"
+	}
+	1360.1.2 = {
+		death="1360.1.2"
+	}
+}
+
+470185 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19060
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="scholarly_theologian"
+	father=470181
+	mother=470182
+	1311.1.2 = {
+		birth="1311.1.2"
+	}
+	1361.1.2 = {
+		death="1361.1.2"
+	}
+}
+
+470186 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19060
+	martial=5
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="lustful"
+	trait="tough_soldier"
+	father=470181
+	mother=470182
+	1313.1.2 = {
+		birth="1313.1.2"
+	}
+	1363.1.2 = {
+		death="1363.1.2"
+	}
+}
+
+470187 = {
+	name="Klára"
+	# AKA: Klara
+	female=yes
+	dynasty=19060
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="lustful"
+	trait="naive_appeaser"
+	father=470181
+	mother=470182
+	1311.1.2 = {
+		birth="1311.1.2"
+	}
+	1361.1.2 = {
+		death="1361.1.2"
+	}
+}
+
+470190 = {
+	name="Ábrahám"
+	# AKA: abraham
+	dynasty=19061
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="lustful"
+	trait="tough_soldier"
+	father=93635
+	1246.1.1 = {
+		birth="1246.1.1"
+	}
+	1307.1.1 = {
+		death="1307.1.1"
+	}
+}
+
+470191 = {
+	name="Péter"
+	dynasty=19061
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="craven"
+	trait="temperate"
+	trait="elusive_shadow"
+	father=470190
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1327.1.1 = {
+		add_spouse=470194
+	}
+	1347.1.1 = {
+		death="1347.1.1"
+	}
+}
+
+470192 = {
+	name="Sebes"
+	dynasty=19061
+	martial=7
+	diplomacy=7
+	intrigue=3
+	stewardship=2
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="proud"
+	trait="tough_soldier"
+	father=470190
+	1290.1.1 = {
+		birth="1290.1.1"
+	}
+	1330.1.1 = {
+		add_spouse=470187
+	}
+	1348.1.1 = {
+		death="1348.1.1"
+	}
+}
+
+470193 = {
+	name="György"
+	dynasty=19061
+	martial=5
+	diplomacy=7
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	father=470192
+	mother=470187
+	1336.1.2 = {
+		birth="1336.1.2"
+	}
+	1386.1.2 = {
+		death="1386.1.2"
+	}
+}
+
+470194 = {
+	name="Pona"
+	female=yes
+	martial=4
+	diplomacy=4
+	intrigue=3
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="honest"
+	trait="naive_appeaser"
+	1306.1.2 = {
+		birth="1306.1.2"
+	}
+	1360.1.2 = {
+		death="1360.1.2"
+	}
+}
+
+470200 = {
+	name="Bereck"
+	dynasty=19062
+	martial=5
+	diplomacy=7
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="martial_cleric"
+	father=93642
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1320.1.1 = {
+		death="1320.1.1"
+	}
+}
+
+470201 = {
+	name="András"
+	# AKA: Andras
+	dynasty=19062
+	martial=2
+	diplomacy=7
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="scholarly_theologian"
+	father=470200
+	1295.1.2 = {
+		birth="1295.1.2"
+	}
+	1345.1.2 = {
+		death="1345.1.2"
+	}
+}
+
+470202 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19062
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="lustful"
+	trait="brave"
+	trait="tough_soldier"
+	father=470200
+	1301.1.2 = {
+		birth="1301.1.2"
+	}
+	1351.1.2 = {
+		death="1351.1.2"
+	}
+}
+
+470203 = {
+	name="Lõkös"
+	# AKA: Lokos
+	dynasty=19062
+	martial=4
+	diplomacy=8
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="charitable"
+	trait="tough_soldier"
+	father=470200
+	1303.1.2 = {
+		birth="1303.1.2"
+	}
+	1330.1.10 = {
+		death="1330.1.10"
+	}
+}
+
+470204 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19062
+	martial=4
+	diplomacy=8
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="charitable"
+	trait="tough_soldier"
+	father=470200
+	1305.1.2 = {
+		birth="1305.1.2"
+	}
+	1355.1.2 = {
+		death="1355.1.2"
+	}
+}
+
+470205 = {
+	name="Benedek"
+	dynasty=19062
+	martial=5
+	diplomacy=6
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="charitable"
+	trait="tough_soldier"
+	father=470203
+	1322.1.2 = {
+		birth="1322.1.2"
+	}
+	1372.1.2 = {
+		death="1372.1.2"
+	}
+}
+
+470206 = {
+	name="Péter"
+	dynasty=19062
+	martial=6
+	diplomacy=4
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470203
+	1325.1.2 = {
+		birth="1325.1.2"
+	}
+	1375.1.2 = {
+		death="1375.1.2"
+	}
+}
+
+470210 = {
+	name="Benedek"
+	dynasty=19014
+	martial=6
+	diplomacy=6
+	intrigue=6
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="brave"
+	trait="tough_soldier"
+	1279.1.2 = {
+		birth="1279.1.2"
+	}
+	1322.1.10 = {
+		death="1322.1.10"
+	}
+}
+
+470212 = {
+	name="Jakab"
+	dynasty=19014
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="brave"
+	trait="tough_soldier"
+	father=470210
+	1299.1.2 = {
+		birth="1299.1.2"
+	}
+	1349.1.2 = {
+		death="1349.1.2"
+	}
+}
+
+470213 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19014
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="cynical"
+	trait="slothful"
+	trait="pneumonic"
+	trait="tough_soldier"
+	father=470210
+	1300.1.2 = {
+		birth="1300.1.2"
+	}
+	1350.1.2 = {
+		death="1350.1.2"
+	}
+}
+
+470214 = {
+	name="Rafain"
+	dynasty=19014
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="greedy"
+	trait="brave"
+	trait="tough_soldier"
+	father=470210
+	1302.1.2 = {
+		birth="1302.1.2"
+	}
+	1352.1.2 = {
+		death="1352.1.2"
+	}
+}
+
+470215 = {
+	name="András"
+	# AKA: Andras
+	dynasty=19014
+	martial=5
+	diplomacy=1
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="arbitrary"
+	trait="misguided_warrior"
+	father=470210
+	1308.1.2 = {
+		birth="1308.1.2"
+	}
+	1358.1.2 = {
+		death="1358.1.2"
+	}
+}
+
+470216 = {
+	name="Pál"
+	# AKA: Pal
+	dynasty=19014
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="proud"
+	trait="honest"
+	trait="tough_soldier"
+	father=470210
+	1313.1.2 = {
+		birth="1313.1.2"
+	}
+	1363.1.2 = {
+		death="1363.1.2"
+	}
+}
+
+470217 = {
+	name="Dózsa"
+	# AKA: Dozsa
+	dynasty=19014
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="slothful"
+	trait="proud"
+	trait="scholarly_theologian"
+	father=470210
+	1319.1.2 = {
+		birth="1319.1.2"
+	}
+	1369.1.2 = {
+		death="1369.1.2"
+	}
+}
+
+470218 = {
+	name="Klára"
+	# AKA: Klara
+	female=yes
+	dynasty=19014
+	martial=2
+	diplomacy=5
+	intrigue=3
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="charitable"
+	trait="thrifty_clerk"
+	father=470210
+	1310.1.2 = {
+		birth="1310.1.2"
+	}
+	1360.1.2 = {
+		death="1360.1.2"
+	}
+}
+
+471 = {
+	name="Zsófia"
+	# AKA: Zsofia
+	female=yes
+	dynasty=708
+	martial=8
+	diplomacy=8
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="diligent"
+	father=470
+	mother=763
+	1046.1.1 = {
+		birth="1046.1.1"
+	}
+	1095.6.18 = {
+		death="1095.6.18"
+	}
+}
+
+472 = {
+	name="Géza"
+	# AKA: Geza
+	dynasty=708
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="kind"
+	trait="chaste"
+	trait="honest"
+	trait="charismatic_negotiator"
+	father=470
+	mother=763
+	1044.1.1 = {
+		birth="1044.1.1"
+	}
+	1062.1.1 = {
+		add_spouse=479
+	}
+	1077.4.25 = {
+		death="1077.4.25"
+	}
+}
+
+473 = {
+	name="Eufémia"
+	# AKA: Eufemia
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=4
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="honest"
+	trait="thrifty_clerk"
+	father=470
+	mother=763
+	1049.1.1 = {
+		birth="1049.1.1"
+	}
+	1066.1.1 = {
+	employer=472
+	}
+	1111.4.2 = {
+		death="1111.4.2"
+	}
+}
+
+474 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=708
+	martial=6
+	diplomacy=5
+	intrigue=5
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="just"
+	trait="proud"
+	trait="gluttonous"
+	trait="honest"
+	trait="brilliant_strategist"
+	father=470
+	mother=763
+	1047.1.1 = {
+		birth="1047.1.1"
+	}
+	1077.1.1 = {
+		add_spouse=1399
+	}
+	1095.7.29 = {
+		death="1095.7.29"
+	}
+}
+
+475 = {
+	name="Ilona"
+	female=yes
+	dynasty=708
+	martial=8
+	diplomacy=4
+	intrigue=8
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="gluttonous"
+	trait="elusive_shadow"
+	father=470
+	mother=763
+	1048.1.1 = {
+		birth="1048.1.1"
+	}
+	1091.1.1 = {
+		death="1091.1.1"
+	}
+}
+
+476 = {
+	name="Salamon"
+	dynasty=708
+	martial=6
+	diplomacy=4
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="cynical"
+	trait="tough_soldier"
+	father=468
+	mother=637
+	1053.1.1 = {
+		birth="1053.1.1"
+	}
+	1063.1.1 = {
+		add_spouse=1476
+	}
+	1087.1.1 = {
+		death="1087.1.1"
+	}
+}
+
+477 = {
+	name="Adelaida"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=7
+	intrigue=8
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="gluttonous"
+	trait="scholarly_theologian"
+	father=468
+	mother=637
+	1040.1.1 = {
+		birth="1040.1.1"
+	}
+	1062.1.27 = {
+		death="1062.1.27"
+	}
+}
+
+478 = {
+	name="Dávid"
+	# AKA: David
+	dynasty=708
+	martial=8
+	diplomacy=5
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="arbitrary"
+	trait="tough_soldier"
+	father=468
+	mother=637
+	1054.1.1 = {
+		birth="1054.1.1"
+	}
+	1066.1.1 = {
+	employer=476
+	}
+	1094.1.1 = {
+		death="1094.1.1"
+	}
+}
+
+480 = {
+	name="Kálmán"
+	# AKA: Kalman
+	dynasty=708
+	martial=5
+	diplomacy=8
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="hunchback"
+	trait="scholarly_theologian"
+	father=472
+	mother=479
+	1065.1.1 = {
+		birth="1065.1.1"
+	}
+	1097.1.2 = {
+	capital=k_hungary
+	}
+	1097.1.2 = {
+		add_spouse=98008
+	}
+	1104.1.2 = {
+		add_spouse=98018
+	}
+	1112.1.2 = {
+	remove_spouse=98018
+	}
+	1116.2.3 = {
+		death="1116.2.3"
+	}
+}
+
+482 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=708
+	martial=6
+	diplomacy=5
+	intrigue=6
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="patient"
+	trait="diligent"
+	trait="martial_cleric"
+	father=464
+	mother=753
+	975.1.1 = {
+		birth="975.1.1"
+	}
+	996.1.1 = {
+		add_spouse=1297
+	}
+	1038.8.15 = {
+		death="1038.8.15"
+	}
+}
+
+484 = {
+	name="Tátony"
+	# AKA: Tatony
+	dynasty=180
+	female=yes
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="tengri_pagan"
+	culture="hungarian"
+	trait="honest"
+	trait="fortune_builder"
+	995.1.1 = {
+		birth="995.1.1"
+	}
+	1052.1.1 = {
+		death="1052.1.1"
+	}
+}
+
+485 = {
+	name="Levente"
+	dynasty=708
+	martial=7
+	diplomacy=6
+	intrigue=3
+	stewardship=4
+	religion="tengri_pagan"
+	culture="hungarian"
+	trait="charitable"
+	trait="cynical"
+	trait="tough_soldier"
+	father=466
+	mother=484
+	1018.1.1 = {
+		birth="1018.1.1"
+	}
+	1047.1.1 = {
+		death="1047.1.1"
+	}
+}
+
+486 = {
+	name="György"
+	dynasty=708
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="bastard"
+	trait="diligent"
+	trait="thrifty_clerk"
+	father=468
+	1037.1.1 = {
+		birth="1037.1.1"
+	}
+	1066.1.1 = {
+	employer=984
+	}
+	1090.1.1 = {
+		death="1090.1.1"
+	}
+}
+
+487 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=708
+	martial=4
+	diplomacy=5
+	intrigue=7
+	stewardship=4
+	religion="tengri_pagan"
+	culture="hungarian"
+	trait="wroth"
+	trait="misguided_warrior"
+	father=462
+	mother=759
+	975.1.1 = {
+		birth="975.1.1"
+	}
+	1029.1.1 = {
+		death="1029.1.1"
+	}
+}
+
+488 = {
+	name="Ottó"
+	# AKA: Otto
+	dynasty=708
+	martial=5
+	diplomacy=4
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=482
+	mother=1297
+	1002.1.1 = {
+		birth="1002.1.1"
+	}
+	1010.1.1 = {
+		death="1010.1.1"
+	}
+}
+
+489 = {
+	name="Imre"
+	dynasty=708
+	martial=7
+	diplomacy=8
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="honest"
+	trait="kind"
+	trait="martial_cleric"
+	father=482
+	mother=1297
+	1007.1.1 = {
+		birth="1007.1.1"
+	}
+	1031.11.2 = {
+		death="1031.11.2"
+	}
+}
+
+490 = {
+	name="Odola"
+	dynasty=708
+	female=yes
+	martial=4
+	diplomacy=4
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="arbitrary"
+	trait="naive_appeaser"
+	father=464
+	mother=753
+	971.1.1 = {
+		birth="971.1.1"
+	}
+	1023.1.1 = {
+		death="1023.1.1"
+	}
+}
+
+491 = {
+	name="Sára"
+	# AKA: Sara
+	female=yes
+	dynasty=19053
+	martial=6
+	diplomacy=5
+	intrigue=8
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="kind"
+	trait="wroth"
+	trait="amateurish_plotter"
+	father=4427
+	1016.1.1 = {
+		birth="1016.1.1"
+	}
+	1066.1.1 = {
+	employer=20369
+	}
+	1070.1.1 = {
+		death="1070.1.1"
+	}
+}
+
+492 = {
+	name="Ilona"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=7
+	intrigue=3
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="ill"
+	trait="diligent"
+	trait="scholarly_theologian"
+	father=464
+	mother=753
+	973.1.1 = {
+		birth="973.1.1"
+	}
+	1000.1.1 = {
+		death="1000.1.1"
+	}
+}
+
+495 = {
+	name="Mária"
+	# AKA: Maria
+	female=yes
+	dynasty=708
+	martial=2
+	diplomacy=7
+	intrigue=8
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="thrifty_clerk"
+	father=464
+	mother=759
+	989.1.1 = {
+		birth="989.1.1"
+	}
+	1026.1.1 = {
+		death="1026.1.1"
+	}
+}
+
+497 = {
+	name="Péter"
+	# AKA: Pietro Oddone
+	dynasty=101562
+	martial=4
+	diplomacy=4
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="envious"
+	trait="craven"
+	trait="underhanded_rogue"
+	father=496
+	mother=495
+	1011.1.1 = {
+		birth="1011.1.1"
+	}
+	1050.1.1= { 
+		add_spouse=30213
+	}
+	1055.1.1= { 
+	remove_spouse=30213
+	}
+	1060.8.30 = {
+		death="1060.8.30"
+	}
+}
+
+499 = {
+	name="Sarolta"
+	dynasty=708
+	female=yes
+	martial=3
+	diplomacy=4
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="intricate_webweaver"
+	father=464
+	mother=759
+	987.1.1 = {
+		birth="987.1.1"
+	}
+	1053.1.1 = {
+		death="1053.1.1"
+	}
+}
+
+599 = {
+	name="Predslava"
+	# AKA: Predeslava
+	female=yes
+	religion="pagan"
+	culture="hungarian"
+	942.1.2 = {
+		birth="942.1.2"
+	}
+	980.1.2 = {
+		death="980.1.2"
+	}
+}
+
+98000 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=708
+	martial=4
+	diplomacy=6
+	intrigue=8
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="impaler"
+	trait="proud"
+	trait="intricate_webweaver"
+	father=219530
+	mother=218511
+	1131.1.2 = {
+		birth="1131.1.2"
+	}
+	1136.1.2 = {
+		add_spouse=221513
+	}
+	1147.6.1 = {
+	remove_spouse=221513
+	}
+	1163.1.14 = {
+		death="1163.1.14"
+	}
+}
+
+98001 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=708
+	martial=2
+	diplomacy=4
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="slothful"
+	trait="proud"
+	trait="naive_appeaser"
+	father=219530
+	mother=218511
+	1133.1.2 = {
+		birth="1133.1.2"
+	}
+	1156.1.2 = {
+		add_spouse=223021
+	}
+	1165.4.11 = {
+		death="1165.4.11"
+	}
+}
+
+98002 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=708
+	martial=2
+	diplomacy=1
+	intrigue=4
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="ill"
+	trait="amateurish_plotter"
+	father=219501
+	mother=210503
+	1199.1.2 = {
+		birth="1199.1.2"
+	}
+	#1146.1.2 = {
+	#add_spouse=222573
+	#}
+	1205.5.7 = {
+		death="1205.5.7"
+	}
+}
+
+98003 = {
+	name="Béla"
+	dynasty=708
+	martial=6
+	diplomacy=5
+	intrigue=8
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="brave"
+	trait="skilled_tactician"
+	father=219502
+	mother=212946
+	1206.11.29 = {
+		birth="1206.11.29"
+	}
+	1218.1.2 = {
+		add_spouse=98033
+	}
+	1270.5.3 = {
+		death="1270.5.3"
+	}
+}
+
+98004 = {
+	name="István"
+	dynasty=708
+	martial=6
+	diplomacy=5
+	intrigue=8
+	stewardship=2
+	religion="catholic"
+	culture="hungarian"
+	trait="greedy"
+	trait="envious"
+	trait="deceitful"
+	trait="tough_soldier"
+	father=98003
+	mother=98033
+	1239.11.1 = {
+		birth="1239.11.1"
+	}
+	1253.1.2 = {
+		add_spouse=98042
+	}
+	1272.8.6 = {
+		death="1272.8.6"
+	}
+}
+
+98005 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=708
+	martial=6
+	diplomacy=5
+	intrigue=5
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="hedonist"
+	trait="indulgent_wastrel"
+	father=98004
+	1262.8.5 = {
+	birth="1262.8.5"
+	}
+	1278.1.1 = {
+		add_spouse=32789 #Elizabeth d'Anjou
+	} 
+	1290.7.10 = {
+	death="1290.7.10"
+	}
+}
+
+98006 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=708
+	martial=2
+	diplomacy=7
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="duelist"
+	trait="gregarious"
+	trait="intricate_webweaver"
+	father=219502
+	mother=98025
+	1236.1.1 = {
+		birth="1236.1.1"
+	}
+	1264.1.2 = {
+		add_spouse=182018 #Tomasini Morosini
+	}
+	1271.1.1 = {
+		death="1271.1.1"
+	}
+}
+
+98007 = {
+	name="András"
+	# AKA: Andras
+	dynasty=708
+	martial=1
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="slow"
+	trait="craven"
+	trait="underhanded_rogue"
+	father=98006
+	mother=182018 #Tomasini Morosini
+	1265.1.2 = {
+		birth="1265.1.2"
+	}
+	1301.1.14 = {
+		death="1301.1.14"
+	}
+}
+
+98011 = {
+	name="Erzsebet"
+	female=yes
+	dynasty=708
+	martial=1
+	diplomacy=3
+	intrigue=8
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="trusting"
+	trait="zealous"
+	trait="grey_eminence"
+	father=98003
+	mother=98033
+	1236.1.1 = {
+		birth="1236.1.1"
+	}
+	1271.10.24 = {
+		death="1271.10.24"
+	}
+}
+
+98012 = {
+	name="Anna"
+	female=yes
+	dynasty=708
+	martial=2
+	diplomacy=5
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="content"
+	trait="gregarious"
+	trait="underhanded_rogue"
+	father=98003
+	mother=98033
+	1227.1.1 = {
+		birth="1227.1.1"
+	}
+	1270.1.2 = {
+		death="1270.1.2"
+	}
+}
+
+98017 = {
+	name="Adelhaid"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=5
+	intrigue=8
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	father=470
+	mother=763
+	1050.1.1 = {
+		birth="1050.1.1"
+	}
+	1104.1.2 = {
+		death="1104.1.2"
+	}
+}
+
+98019 = {
+	name="Hedwig"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=8
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	father=219531
+	mother=219532
+	1111.1.2 = {
+		birth="1111.1.2"
+	}
+	1140.1.2 = {
+		death="1140.1.2"
+	}
+}
+
+98020 = {
+	name="Maria"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=4
+	intrigue=6
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	father=98000
+	mother=221513
+	1147.1.2 = {
+		birth="1147.1.2"
+	}
+	1183.1.2 = {
+		death="1183.1.2"
+	}
+}
+
+98021 = {
+	name="Odola"
+	female=yes
+	dynasty=708
+	martial=7
+	diplomacy=8
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	father=219510
+	mother=222573
+	1156.1.2 = {
+		birth="1156.1.2"
+	}
+	1199.1.2 = {
+		death="1199.1.2"
+	}
+}
+
+98023 = {
+	name="Béla"
+	# AKA: Bela
+	dynasty=708
+	martial=1
+	diplomacy=2
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	father=219511
+	mother=212542
+	1167.1.2 = {
+		birth="1167.1.2"
+	}
+	1167.3.5 = {
+		death="1167.3.5"
+	}
+}
+
+98026 = {
+	name="Anna Maria"
+	# AKA: Maria
+	female=yes
+	dynasty=708
+	martial=2
+	diplomacy=8
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	father=219502
+	mother=212946
+	1204.1.1 = {
+		birth="1204.1.1"
+	}
+	1238.1.1 = {
+		death="1238.1.1"
+	}
+}
+
+98027 = {
+	name="Erzsébet"
+	female=yes
+	dynasty=708
+	martial=6
+	diplomacy=8
+	intrigue=2
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	father=219502
+	mother=212946
+	1207.7.7 = {
+		birth="1207.7.7"
+	}
+	1231.11.17 = {
+		death="1231.11.17"
+	}
+}
+
+98028 = {
+	name="Kálmán"
+	# AKA: Kalman
+	dynasty=708
+	martial=8
+	diplomacy=5
+	intrigue=3
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	father=219502
+	mother=212946
+	1208.1.1 = {
+		birth="1208.1.1"
+	}
+    1241.1.1 = {
+		add_spouse=125981
+    }
+	1241.4.11 = {
+		death="1241.4.11"
+	}
+}
+
+98029 = {
+	name="András"
+	# AKA: Andras
+	dynasty=708
+	martial=8
+	diplomacy=5
+	intrigue=3
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	father=219502
+	mother=212946
+	1211.1.2 = {
+		birth="1211.1.2"
+	}
+	1227.1.2 = {
+		add_spouse=125148
+	}
+	1234.1.1 = {
+		death="1234.1.1"
+	}
+}
+
+98030 = {
+	name="Yolande"
+	# AKA: Jolan
+	female=yes
+	dynasty=708
+	martial=7
+	diplomacy=4
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	father=219502
+	mother=98024
+	1215.11.2 = {
+		birth="1215.11.2"
+	}
+	1251.10.9 = {
+		death="1251.10.9"
+	}
+}
+
+98049 = {
+	name="Katalin"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=8
+	intrigue=2
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	father=474
+	mother=1399
+	1072.1.2 = {
+		birth="1072.1.2"
+	}
+	1107.1.2 = {
+		death="1107.1.2"
+	}
+}
+
+98031 = {
+	name="Geza"
+	dynasty=708
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="charismatic_negotiator"
+	father=219517
+	1190.1.2 = {
+		birth="1190.1.2"
+	}
+	1212.1.2 = {
+		death="1212.1.2"
+	}
+}
+
+98032 = {
+	name="István"
+	dynasty=708
+	martial=3
+	diplomacy=7
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=219517
+	1192.1.2 = {
+		birth="1192.1.2"
+	}
+	1215.1.2 = {
+		death="1215.1.2"
+	}
+}
+
+98034 = {
+	name="Kunigunda"
+	female=yes
+	dynasty=708
+	martial=2
+	diplomacy=5
+	intrigue=8
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="mastermind_theologian"
+	father=98003
+	mother=98033
+	1224.1.1 = {
+		birth="1224.1.1"
+	}
+	1292.7.24 = {
+		death="1292.7.24"
+	}
+}
+
+98035 = {
+	name="Margit"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=6
+	intrigue=2
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="fortune_builder"
+	father=98003
+	mother=98033
+	1221.1.1 = {
+		birth="1221.1.1"
+	}
+	1242.4.20 = {
+		death="1242.4.20"
+	}
+}
+
+98036 = {
+	name="Katalin"
+	female=yes
+	dynasty=708
+	martial=3
+	diplomacy=4
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="fortune_builder"
+	father=98003
+	mother=98033
+	1229.1.1 = {
+		birth="1229.1.1"
+	}
+	1242.1.2 = {
+		death="1242.1.2"
+	}
+}
+
+98037 = {
+	name="Konstancia"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=8
+	intrigue=2
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="fortune_builder"
+	father=98003
+	mother=98033
+	1237.1.1 = {
+		birth="1237.1.1"
+	}
+	1298.1.2 = {
+		death="1298.1.2"
+	}
+}
+
+98038 = {
+	name="Jolan"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=5
+	intrigue=6
+	stewardship=1
+	religion="catholic"
+	culture="hungarian"
+	father=98003
+	mother=98033
+	1244.1.1 = {
+		birth="1244.1.1"
+	}
+	1298.3.6 = {
+		death="1298.3.6"
+	}
+}
+
+98039 = {
+	name="Margit"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=5
+	intrigue=6
+	stewardship=1
+	religion="catholic"
+	culture="hungarian"
+	trait="mastermind_theologian"
+	father=98003
+	mother=98033
+	1242.5.1 = {
+		birth="1242.5.1"
+	}
+	1270.1.18 = {
+		death="1270.1.18"
+	}
+}
+
+98040 = {
+	name="Béla"
+	dynasty=708
+	martial=5
+	diplomacy=7
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="mastermind_theologian"
+	father=98003
+	mother=98033
+	1243.1.1 = {
+		birth="1243.1.1"
+	}
+	1264.10.25 = {
+		add_spouse=98041
+	}
+	1269.1.1 = {
+		death="1269.1.1"
+	}
+}
+
+98043 = {
+	name="Katalin"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=3
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	father=98004
+	mother=98042
+	1256.1.2 = {
+		birth="1256.1.2"
+	}
+	1314.1.2 = {
+		death="1314.1.2"
+	}
+}
+
+98044 = {
+	name="Erzsébet"
+	female=yes
+	dynasty=708
+	martial=6
+	diplomacy=8
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	father=98004
+	mother=98042
+	1255.1.2 = {
+		birth="1255.1.2"
+	}
+	1326.1.2 = {
+		death="1326.1.2"
+	}
+}
+
+98045 = {
+	name="Agnes"
+	female=yes
+	dynasty=708
+	martial=6
+	diplomacy=4
+	intrigue=7
+	stewardship=2
+	religion="catholic"
+	culture="hungarian"
+	father=98004
+	mother=98042
+	1260.1.2 = {
+		birth="1260.1.2"
+	}
+	1281.1.2 = {
+		death="1281.1.2"
+	}
+}
+
+98046 = {
+	name="András"
+	dynasty=708
+	martial=7
+	diplomacy=2
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	father=98004
+	mother=98042
+	1268.1.2 = {
+		birth="1268.1.2"
+	}
+	1278.1.2 = {
+		death="1278.1.2"
+	}
+}
+
+98047 = {
+	name="Anna"
+	female=yes
+	dynasty=708
+	martial=7
+	diplomacy=2
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	father=98004
+	mother=98042
+	1258.1.1 = {
+		birth="1258.1.1"
+	}
+	1285.1.1 = {
+		death="1285.1.1"
+	}
+}
+
+32637 = {
+	name="Babonjeg" 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1255.1.1 = {
+		death="1255.1.1"
+	}
+}
+
+32638 = {
+	name="Babonjeg" 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32637
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1280.1.1 = {
+		death="1280.1.1"
+	}
+}
+
+32639 = {
+	name="István" #ban of Slavonia 1310-1316
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32638
+	1255.1.1 = {
+		birth="1255.1.1"
+	}
+	1316.1.1 = {
+		death="1316.1.1"
+	}
+}
+
+32640 = {
+	name="István" 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32637
+	1232.1.1 = {
+		birth="1232.1.1"
+	}
+	1282.1.1 = {
+		death="1282.1.1"
+	}
+}
+
+32641 = {
+	name="István" #Ban of Slavonia 1278-1300
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32640
+	1255.1.1 = {
+		birth="1255.1.1"
+	}
+	1300.1.1 = {
+		death="1300.1.1"
+	}
+}
+
+32642 = {
+	name="Radoszló" 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32640
+	1256.1.1 = {
+		birth="1256.1.1"
+	}
+	1299.1.1 = {
+		death="1299.1.1"
+	}
+}
+
+32643 = {
+	name="István" 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32641
+	1290.1.1 = {
+		birth="1290.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+32644 = {
+	name="László" 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32641
+	1288.1.1 = {
+		birth="1288.1.1"
+	}
+	1338.1.1 = {
+		death="1338.1.1"
+	}
+}
+
+32645 = {
+	name="János" #ban of Slavonia 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32638
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1334.1.1 = {
+		death="1334.1.1"
+	}
+}
+
+32646 = {
+	name="Ottó"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32638
+	1262.1.1 = {
+		birth="1262.1.1"
+	}
+	1300.1.1 = {
+		death="1300.1.1"
+	}
+}
+
+32647 = {
+	name="Radoszló"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32638
+	1264.1.1 = {
+		birth="1264.1.1"
+	}
+	1314.1.1 = {
+		death="1314.1.1"
+	}
+}
+
+32648 = {
+	name="Miklós"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32647
+	1286.1.1 = {
+		birth="1286.1.1"
+	}
+	1330.1.1 = {
+		death="1330.1.1"
+	}
+}
+
+32649 = {
+	name="Duim"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32647
+	1292.1.1 = {
+		birth="1292.1.1"
+	}
+	1369.1.1 = {
+		death="1369.1.1"
+	}
+}
+
+32650 = {
+	name="György"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32639
+	1295.1.1 = {
+		birth="1295.1.1"
+	}
+	1336.1.1 = {
+		death="1336.1.1"
+	}
+}
+
+32651 = {
+	name="János"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32639
+	1297.1.1 = {
+		birth="1297.1.1"
+	}
+	1328.1.1 = {
+		death="1328.1.1"
+	}
+}
+
+32652 = {
+	name="Dénes"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32639
+	1300.1.1 = {
+		birth="1300.1.1"
+	}
+	1370.1.1 = {
+		death="1370.1.1"
+	}
+}
+
+32653 = {
+	name="Pál"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32639
+	1305.1.1 = {
+		birth="1305.1.1"
+	}
+	1380.1.1 = {
+		death="1380.1.1"
+	}
+}
+
+32654 = {
+	name="Katalin"
+	female=yes
+	dynasty=19007 #Blagai
+	religion="catholic"
+	culture="hungarian"
+	father=32639
+	1305.1.1 = {
+		birth="1305.1.1"
+	}
+	1380.1.1 = {
+		death="1380.1.1"
+	}
+}
+
+93551 = {
+	name="Hont"
+	dynasty=19053
+	religion="catholic"
+	culture="hungarian"
+	father=20369
+	1095.1.1={
+		birth="1095.1.1"
+	}
+	1155.1.1={
+		death="1155.1.1"
+	}
+}
+
+93552 = {
+	name="Martin"
+	dynasty=19053
+	religion="catholic"
+	culture="hungarian"
+	father=93551
+	1145.1.1={
+		birth="1145.1.1"
+	}
+	1203.1.1={
+		death="1203.1.1"
+	}
+}
+
+93624 = {
+	name="Márton"
+	#placeholder
+	dynasty=101570
+	religion="catholic"
+	culture="hungarian"
+	father=4412
+	1060.1.1={
+		birth="1060.1.1"
+	}
+	1110.1.1={
+		death="1110.1.1"
+	}
+}
+
+93625 = {
+	name="Márton"
+	#placeholder
+	dynasty=101570
+	religion="catholic"
+	culture="hungarian"
+	father=93624
+	1085.1.1={
+		birth="1085.1.1"
+	}
+	1135.1.1={
+		death="1135.1.1"
+	}
+}
+
+93626 = {
+	name="Miska"
+	#placeholder
+	dynasty=101570
+	religion="catholic"
+	culture="hungarian"
+	father=93625
+	1110.1.1={
+		birth="1110.1.1"
+	}
+	1160.1.1={
+		death="1160.1.1"
+	}
+}
+
+93627 = {
+	name="Kupán"
+	#placeholder
+	dynasty=101570
+	religion="catholic"
+	culture="hungarian"
+	father=93626
+	1130.1.1={
+		birth="1130.1.1"
+	}
+	1170.1.1={
+		death="1170.1.1"
+	}
+}
+
+93628 = {
+	name="Ottó"
+	#placeholder
+	dynasty=101568
+	religion="catholic"
+	culture="hungarian"
+	father=4397
+	1080.1.1={
+		birth="1080.1.1"
+	}
+	1140.1.1={
+		death="1140.1.1"
+	}
+}
+
+
+93629 = {
+	name="Tamás"
+	#placeholder
+	dynasty=101568
+	religion="catholic"
+	culture="hungarian"
+	father=93628
+	1110.1.1={
+		birth="1110.1.1"
+	}
+	1170.1.1={
+		death="1170.1.1"
+	}
+}
+
+93630 = {
+	name="Ipoly"
+	#placeholder
+	dynasty=101568
+	religion="catholic"
+	culture="hungarian"
+	father=93629
+	1150.1.1={
+		birth="1150.1.1"
+	}
+	1210.1.1={
+		death="1210.1.1"
+	}
+}
+
+93631 = {
+	name="Imre"
+	#placeholder
+	dynasty=101568
+	religion="catholic"
+	culture="hungarian"
+	father=93630
+	1190.1.1={
+		birth="1190.1.1"
+	}
+	1250.1.1={
+		death="1250.1.1"
+	}
+}
+
+93632 = {
+	name="Miklós"
+	#placeholder
+	dynasty=101568
+	religion="catholic"
+	culture="hungarian"
+	father=93631
+	1230.1.1={
+		birth="1230.1.1"
+	}
+	1290.1.1={
+		death="1290.1.1"
+	}
+}
+
+93633 = {
+	name="Bény"
+	#placeholder
+	dynasty=101568
+	religion="catholic"
+	culture="hungarian"
+	father=93632
+	1270.1.1={
+		birth="1270.1.1"
+	}
+	1320.1.1={
+		death="1320.1.1"
+	}
+}
+
+93634 = {
+	name="Sebes"
+	dynasty=19061
+	religion="catholic"
+	culture="hungarian"
+	1180.1.1 = {
+		birth="1180.1.1"
+	}
+	1239.1.1 = {
+		death="1239.1.1"
+	}
+}
+
+93635 = {
+	name="Ábrahám"
+	dynasty=19061
+	religion="catholic"
+	culture="hungarian"
+	father=93634
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1255.1.1 = {
+		death="1255.1.1"
+	}
+}
+
+93636 = {
+	name="Tamás"
+	dynasty=19061
+	religion="catholic"
+	culture="hungarian"
+	father=93635
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1287.1.1 = {
+		death="1287.1.1"
+	}
+}
+
+93637 = {
+	name="Tamás"
+	dynasty=19061
+	religion="catholic"
+	culture="hungarian"
+	father=470190
+	1270.1.1 = {
+		birth="1270.1.1"
+	}
+	1316.1.1 = {
+		death="1316.1.1"
+	}
+}
+
+93638 = {
+	name="Imre"
+	# Placeholder
+	dynasty=100537
+	religion="catholic"
+	culture="hungarian"
+	1112.1.1 = {
+		birth="1112.1.1"
+	}
+	1170.1.1 = {
+		death="1170.1.1"
+	}
+}
+
+93639 = {
+	name="Miklós"
+	dynasty=19062
+	religion="catholic"
+	culture="hungarian"
+	1206.1.1 = {
+		birth="1206.1.1"
+	}
+	1260.1.1 = {
+		death="1260.1.1"
+	}
+}
+
+93640 = {
+	name="Miklós"
+	dynasty=19062
+	religion="catholic"
+	culture="hungarian"
+	father=93639
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1291.1.1 = {
+		death="1291.1.1"
+	}
+}
+
+93641 = {
+	name="István"
+	dynasty=19062
+	religion="catholic"
+	culture="hungarian"
+	father=93639
+	1235.1.1 = {
+		birth="1235.1.1"
+	}
+	1310.1.1 = {
+		death="1310.1.1"
+	}
+}
+
+93642 = {
+	name="András"
+	dynasty=19062
+	religion="catholic"
+	culture="hungarian"
+	father=93639
+	1240.1.1 = {
+		birth="1240.1.1"
+	}
+	1290.1.1 = {
+		death="1290.1.1"
+	}
+}
+
+93643 = {
+	name="György"
+	dynasty=19062
+	religion="catholic"
+	culture="hungarian"
+	father=93642
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1307.1.1 = {
+		death="1307.1.1"
+	}
+}
+
+93644 = {
+	name="Benedek"
+	dynasty=19062
+	religion="catholic"
+	culture="hungarian"
+	father=93642
+	1265.1.1 = {
+		birth="1265.1.1"
+	}
+	1321.1.1 = {
+		death="1321.1.1"
+	}
+}
+
+93645 = {
+	name="Benedek"
+	# placeholder
+	dynasty=101563
+	religion="catholic"
+	culture="hungarian"
+	father=4358
+	1070.1.1 = {
+		birth="1070.1.1"
+	}
+	1130.1.1 = {
+		death="1130.1.1"
+	}
+}
+
+93646 = {
+	name="György"
+	# placeholder
+	dynasty=101563
+	religion="catholic"
+	culture="hungarian"
+	father=93645
+	1110.1.1 = {
+		birth="1110.1.1"
+	}
+	1170.1.1 = {
+		death="1170.1.1"
+	}
+}
+
+93647 = {
+	name="Belenik"
+	# placeholder
+	dynasty=101563
+	religion="catholic"
+	culture="hungarian"
+	father=93646
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1210.1.1 = {
+		death="1210.1.1"
+	}
+}
+
+93648 = {
+	name="Imre"
+	# placeholder
+	dynasty=101563
+	religion="catholic"
+	culture="hungarian"
+	father=93647
+	1190.1.1 = {
+		birth="1190.1.1"
+	}
+	1250.1.1 = {
+		death="1250.1.1"
+	}
+}
+
+93649 = {
+	name="Lampert"
+	# placeholder
+	dynasty=101563
+	religion="catholic"
+	culture="hungarian"
+	father=93647
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1250.1.1 = {
+		death="1250.1.1"
+	}
+}
+
+93650 = {
+	name="János"
+	dynasty=19059
+	religion="catholic"
+	culture="hungarian"
+	father=470101
+	1326.1.1 = {
+		birth="1326.1.1"
+	}
+	1394.1.1 = {
+		death="1394.1.1"
+	}
+}
+
+93651 = {
+	name="Beled"
+	dynasty=19058
+	religion="catholic"
+	culture="hungarian"
+	father=470090
+	1210.1.1 = {
+		birth="1210.1.1"
+	}
+	1236.1.1 = {
+		death="1236.1.1"
+	}
+}
+
+93652 = {
+	name="Kálmán"
+	# placeholder
+	dynasty=100450
+	religion="catholic"
+	culture="hungarian"
+	1077.1.1 = {
+		birth="1077.1.1"
+	}
+	1130.1.1 = {
+		death="1130.1.1"
+	}
+}
+
+93653 = {
+	name="Dávid"
+	# placeholder
+	dynasty=100450
+	religion="catholic"
+	culture="hungarian"
+	father=93652
+	1110.1.1 = {
+		birth="1110.1.1"
+	}
+	1160.1.1 = {
+		death="1160.1.1"
+	}
+}
+
+93654 = {
+	name="László"
+	# placeholder
+	dynasty=100450
+	religion="catholic"
+	culture="hungarian"
+	father=93653
+	1130.1.1 = {
+		birth="1130.1.1"
+	}
+	1180.1.1 = {
+		death="1180.1.1"
+	}
+}
+
+93655 = {
+	name="Elek" #real name unknown
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=4386
+	1070.1.1 = {
+		birth="1070.1.1"
+	}
+	1130.1.1 = {
+		death="1130.1.1"
+	}
+}
+
+93656 = {
+	name="Imre" #real name unknown
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93655
+	1100.1.1 = {
+		birth="1100.1.1"
+	}
+	1160.1.1 = {
+		death="1160.1.1"
+	}
+}
+
+93657 = {
+	name="Fülöp" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93656
+	1130.1.1 = {
+		birth="1130.1.1"
+	}
+	1190.1.1 = {
+		death="1190.1.1"
+	}
+}
+
+93658 = {
+	name="Benedek" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93656
+	1135.1.1 = {
+		birth="1135.1.1"
+	}
+	1195.1.1 = {
+		death="1195.1.1"
+	}
+}
+
+93659 = {
+	name="Bogyoszló" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93656
+	1140.1.1 = {
+		birth="1140.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+93660 = {
+	name="Kelemen" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93658
+	1160.1.1 = {
+		birth="1160.1.1"
+	}
+	1218.1.1 = {
+		death="1218.1.1"
+	}
+}
+
+93661 = {
+	name="Waffa" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93658
+	1163.1.1 = {
+		birth="1163.1.1"
+	}
+	1238.1.1 = {
+		death="1238.1.1"
+	}
+}
+
+93662 = {
+	name="Pongrácz"
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93660
+	1185.1.1 = {
+		birth="1185.1.1"
+	}
+	1256.1.1 = {
+		death="1256.1.1"
+	}
+}
+
+93663 = {
+	name="Izsák"
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93660
+	1187.1.1 = {
+		birth="1187.1.1"
+	}
+	1256.1.1 = {
+		death="1256.1.1"
+	}
+}
+
+93664 = {
+	name="Elek"
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93660
+	1189.1.1 = {
+		birth="1189.1.1"
+	}
+	1256.1.1 = {
+		death="1256.1.1"
+	}
+}
+
+93665 = {
+	name="Csömör"
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93660
+	1191.1.1 = {
+		birth="1191.1.1"
+	}
+	1256.1.1 = {
+		death="1256.1.1"
+	}
+}
+
+93666 = {
+	name="László"
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93662
+	1235.1.1 = {
+		birth="1235.1.1"
+	}
+	1282.1.1 = {
+		death="1282.1.1"
+	}
+}
+
+93667 = {
+	name="Makó"
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93663
+	1217.1.1 = {
+		birth="1217.1.1"
+	}
+	1285.1.1 = {
+		death="1285.1.1"
+	}
+}
+
+93668 = {
+	name="Csanád" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93661
+	1193.1.1 = {
+		birth="1193.1.1"
+	}
+	1256.1.1 = {
+		death="1256.1.1"
+	}
+}
+
+93669 = {
+	name="Dénes" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93668
+	1223.1.1 = {
+		birth="1223.1.1"
+	}
+	1290.1.1 = {
+		death="1290.1.1"
+	}
+}
+
+93670 = {
+	name="Gergely" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93668
+	1228.1.1 = {
+		birth="1228.1.1"
+	}
+	1299.1.1 = {
+		death="1299.1.1"
+	}
+}
+
+93671 = {
+	name="István" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93669
+	1253.1.1 = {
+		birth="1253.1.1"
+	}
+	1299.1.1 = {
+		death="1299.1.1"
+	}
+}
+
+93672 = {
+	name="Pál" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93669
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1332.1.1 = {
+		death="1332.1.1"
+	}
+}
+
+93673 = {
+	name="Dénes" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93669
+	1265.1.1 = {
+		birth="1265.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+93674 = {
+	name="Pál" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93671
+	1290.1.1 = {
+		birth="1290.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+93675 = {
+	name="Péter" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93671
+	1292.1.1 = {
+		birth="1292.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+93676 = {
+	name="Dénes" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93674
+	1323.1.1 = {
+		birth="1323.1.1"
+	}
+	1373.1.1 = {
+		death="1373.1.1"
+	}
+}
+
+93677 = {
+	name="Pál" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93674
+	1325.1.1 = {
+		birth="1325.1.1"
+	}
+	1375.1.1 = {
+		death="1375.1.1"
+	}
+}
+
+93678 = {
+	name="Szabolcs" #real name unknown
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	mother=4436
+	1090.1.1 = {
+		birth="1090.1.1"
+	}
+	1150.1.1 = {
+		death="1150.1.1"
+	}
+}
+
+93679 = {
+	name="István" #real name unknown
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93678
+	1130.1.1 = {
+		birth="1130.1.1"
+	}
+	1180.1.1 = {
+		death="1180.1.1"
+	}
+}
+
+93680 = {
+	name="Máté" #real name unknown
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93679
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+93681 = {
+	name="Ugrin" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93680
+	1170.1.1 = {
+		birth="1170.1.1"
+	}
+	1204.1.1 = {
+		death="1204.1.1"
+	}
+}
+
+93682 = {
+	name="Miklós" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93680
+	1180.1.1 = {
+		birth="1180.1.1"
+	}
+	1239.1.1 = {
+		death="1239.1.1"
+	}
+}
+
+93683 = {
+	name="Máté" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93680
+	1185.1.1 = {
+		birth="1185.1.1"
+	}
+	1249.1.1 = {
+		death="1249.1.1"
+	}
+}
+
+93684 = {
+	name="Izsák" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93682
+	1196.1.1 = {
+		birth="1196.1.1"
+	}
+	1240.1.1 = {
+		death="1240.1.1"
+	}
+}
+
+93685 = {
+	name="Lörinc" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93682
+	1210.1.1 = {
+		birth="1210.1.1"
+	}
+	1278.1.1 = {
+		death="1278.1.1"
+	}
+}
+
+93686 = {
+	name="Lörinc" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93685
+	1240.1.1 = {
+		birth="1240.1.1"
+	}
+	1290.1.1 = {
+		death="1290.1.1"
+	}
+}
+
+93687 = {
+	name="János" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93686
+	1270.1.1 = {
+		birth="1270.1.1"
+	}
+	1358.1.1 = {
+		death="1358.1.1"
+	}
+}
+
+93688 = {
+	name="János" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93682
+	1215.1.1 = {
+		birth="1215.1.1"
+	}
+	1278.1.1 = {
+		death="1278.1.1"
+	}
+}
+
+93689 = {
+	name="Domokos" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93688
+	1245.1.1 = {
+		birth="1245.1.1"
+	}
+	1305.1.1 = {
+		death="1305.1.1"
+	}
+}
+
+93690 = {
+	name="Ugrin" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93688
+	1247.1.1 = {
+		birth="1247.1.1"
+	}
+	1305.1.1 = {
+		death="1305.1.1"
+	}
+}
+
+93691 = {
+	name="János" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93688
+	1250.1.1 = {
+		birth="1250.1.1"
+	}
+	1305.1.1 = {
+		death="1305.1.1"
+	}
+}
+
+93692 = {
+	name="Egyed" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93689
+	1265.1.1 = {
+		birth="1265.1.1"
+	}
+	1317.1.1 = {
+		death="1317.1.1"
+	}
+}
+
+93693 = {
+	name="János" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93689
+	1270.1.1 = {
+		birth="1270.1.1"
+	}
+	1317.1.1 = {
+		death="1317.1.1"
+	}
+}
+
+93694 = {
+	name="Pál" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93690
+	1277.1.1 = {
+		birth="1277.1.1"
+	}
+	1358.1.1 = {
+		death="1358.1.1"
+	}
+}
+
+93695 = {
+	name="István" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93694
+	1300.1.1 = {
+		birth="1300.1.1"
+	}
+	1363.1.1 = {
+		death="1363.1.1"
+	}
+}
+
+93696 = {
+	name="Miklós" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93694
+	1302.1.1 = {
+		birth="1302.1.1"
+	}
+	1363.1.1 = {
+		death="1363.1.1"
+	}
+}
+
+93697 = {
+	name="János" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93694
+	1304.1.1 = {
+		birth="1304.1.1"
+	}
+	1363.1.1 = {
+		death="1363.1.1"
+	}
+}
+
+93698 = {
+	name="Péter" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93697
+	1334.1.1 = {
+		birth="1334.1.1"
+	}
+	1405.1.1 = {
+		death="1405.1.1"
+	}
+}
+
+93699 = {
+	name="Márk" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93683
+	1205.1.1 = {
+		birth="1205.1.1"
+	}
+	1259.1.1 = {
+		death="1259.1.1"
+	}
+}
+
+93700 = {
+	name="István" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93683
+	1210.1.1 = {
+		birth="1210.1.1"
+	}
+	1288.1.1 = {
+		death="1288.1.1"
+	}
+}
+
+93701 = {
+	name="Máté" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93683
+	1215.1.1 = {
+		birth="1215.1.1"
+	}
+	1284.1.1 = {
+		death="1284.1.1"
+	}
+}
+
+93702 = {
+	name="István" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93699
+	1235.1.1 = {
+		birth="1235.1.1"
+	}
+	1307.1.1 = {
+		death="1307.1.1"
+	}
+}
+
+93703 = {
+	name="Péter" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93699
+	1240.1.1 = {
+		birth="1240.1.1"
+	}
+	1290.1.1 = {
+		death="1290.1.1"
+	}
+}
+
+93704 = {
+	name="Péter" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93702
+	1265.1.1 = {
+		birth="1265.1.1"
+	}
+	1337.1.1 = {
+		death="1337.1.1"
+	}
+}
+
+93705 = {
+	name="Márk" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93702
+	1267.1.1 = {
+		birth="1267.1.1"
+	}
+	1309.1.1 = {
+		death="1309.1.1"
+	}
+}
+
+93706 = {
+	name="István" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93702
+	1269.1.1 = {
+		birth="1269.1.1"
+	}
+	1329.1.1 = {
+		death="1329.1.1"
+	}
+}
+
+93707 = {
+	name="Domokos" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93704
+	1295.1.1 = {
+		birth="1295.1.1"
+	}
+	1359.1.1 = {
+		death="1359.1.1"
+	}
+}
+
+93708 = {
+	name="László" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93704
+	1297.1.1 = {
+		birth="1297.1.1"
+	}
+	1332.1.1 = {
+		death="1332.1.1"
+	}
+}
+
+93709 = {
+	name="Péter" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93704
+	1299.1.1 = {
+		birth="1299.1.1"
+	}
+	1332.1.1 = {
+		death="1332.1.1"
+	}
+}
+
+93710 = {
+	name="László" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93707
+	1325.1.1 = {
+		birth="1325.1.1"
+	}
+	1398.1.1 = {
+		death="1398.1.1"
+	}
+}
+
+93711 = {
+	name="Máté" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=470163
+	1252.1.1 = {
+		birth="1252.1.1"
+	}
+	1321.3.18 = {
+		death="1321.3.18"
+	}
+}
+
+93712 = {
+	name="Máté" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93711
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1321.1.1 = {
+		death="1321.1.1"
+	}
+}
+
+93713 = {
+	name="Máté" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93712
+	1315.1.1 = {
+		birth="1315.1.1"
+	}
+	1356.1.1 = {
+		death="1356.1.1"
+	}
+}
+
+93714 = {
+	name="Jakab" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93712
+	1318.1.1 = {
+		birth="1318.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+93715 = {
+	name="Synk"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1210.1.1 = {
+		death="1210.1.1"
+	}
+}
+
+93716 = {
+	name="Detre"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93715
+	1180.1.1 = {
+		birth="1180.1.1"
+	}
+	1236.1.1 = {
+		death="1236.1.1"
+	}
+}
+
+93717 = {
+	name="Mikó"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93716
+	1198.1.1 = {
+		birth="1198.1.1"
+	}
+	1270.1.2 = {
+		death="1270.1.2"
+	}
+}
+
+93718 = {
+	name="Miklós"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93716
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1246.1.1 = {
+		death="1246.1.1"
+	}
+}
+
+93719 = {
+	name="Detre"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93716
+	1202.1.1 = {
+		birth="1202.1.1"
+	}
+	1254.1.1 = {
+		death="1254.1.1"
+	}
+}
+
+93720 = {
+	name="Biter"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93717
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1297.1.1 = {
+		death="1297.1.1"
+	}
+}
+
+93721 = {
+	name="János"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93717
+	1250.1.1 = {
+		birth="1250.1.1"
+	}
+	1300.1.1 = {
+		death="1300.1.1"
+	}
+}
+
+93722 = {
+	name="Miklós"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93717
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1299.1.1 = {
+		death="1299.1.1"
+	}
+}
+
+93723 = {
+	name="Péter"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93717
+	1265.1.1 = {
+		birth="1265.1.1"
+	}
+	1335.1.1 = {
+		death="1335.1.1"
+	}
+}
+
+93724 = {
+	name="Mihály"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93717
+	1270.1.1 = {
+		birth="1270.1.1"
+	}
+	1300.1.1 = {
+		death="1300.1.1"
+	}
+}
+
+93725 = {
+	name="György"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93722
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1323.1.1 = {
+		death="1323.1.1"
+	}
+}
+
+93726 = {
+	name="Miklós"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93723
+	1295.1.1 = {
+		birth="1295.1.1"
+	}
+	1358.1.1 = {
+		death="1358.1.1"
+	}
+}
+
+93727 = {
+	name="János"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93723
+	1300.1.1 = {
+		birth="1300.1.1"
+	}
+	1349.1.1 = {
+		death="1349.1.1"
+	}
+}
+
+93728 = {
+	name="György"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93723
+	1305.1.1 = {
+		birth="1305.1.1"
+	}
+	1385.1.1 = {
+		death="1385.1.1"
+	}
+}
+
+
+93729 = {
+	name="Anics"
+	female=yes
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93723
+	1306.1.1 = {
+		birth="1306.1.1"
+	}
+	1335.1.1 = {
+		death="1335.1.1"
+	}
+}
+
+93730 = {
+	name="László"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93726
+	1320.1.1 = {
+		birth="1320.1.1"
+	}
+	1365.1.1 = {
+		death="1365.1.1"
+	}
+}
+
+93731 = {
+	name="Balász"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93726
+	1325.1.1 = {
+		birth="1325.1.1"
+	}
+	1388.1.1 = {
+		death="1388.1.1"
+	}
+}
+
+93732 = {
+	name="János"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93726
+	1330.1.1 = {
+		birth="1330.1.1"
+	}
+	1390.8.22 = {
+		death="1390.8.22"
+	}
+}
+
+93733 = {
+	name="Mikó"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93726
+	1335.1.1 = {
+		birth="1335.1.1"
+	}
+	1364.1.1 = {
+		death="1364.1.1"
+	}
+}
+
+93734 = {
+	name="Péter"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93718
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1307.1.1 = {
+		death="1307.1.1"
+	}
+}
+
+93735 = {
+	name="Demeter"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93718
+	1232.1.1 = {
+		birth="1232.1.1"
+	}
+	1312.6.15 = {
+		death="1312.6.15"
+	}
+}
+
+93736 = {
+	name="János"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93734
+	1255.1.1 = {
+		birth="1255.1.1"
+	}
+	1305.1.1 = {
+		death="1305.1.1"
+	}
+}
+
+93737 = {
+	name="Doncs"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93734
+	1256.1.1 = {
+		birth="1256.1.1"
+	}
+	1306.1.1 = {
+		death="1306.1.1"
+	}
+}
+
+93738 = {
+	name="Detrik"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93734
+	1257.1.1 = {
+		birth="1257.1.1"
+	}
+	1307.1.1 = {
+		death="1307.1.1"
+	}
+}
+
+93747 = {
+	name="Klára"
+	female=yes
+	dynasty=12002
+	religion="catholic"
+	culture="hungarian"
+	father=93741
+	1308.1.1 = {
+		birth="1308.1.1"
+	}
+	1351.1.1 = {
+		death="1351.1.1"
+	}
+}
+
+93748 = {
+	name="János"
+	dynasty=12002
+	religion="catholic"
+	culture="hungarian"
+	father=93745
+	1328.1.1 = {
+		birth="1328.1.1"
+	}
+	1374.1.1 = {
+		death="1374.1.1"
+	}
+}
+
+93749 = {
+	name="László"
+	dynasty=12002
+	religion="catholic"
+	culture="hungarian"
+	father=93745
+	1330.1.1 = {
+		birth="1330.1.1"
+	}
+	1371.1.1 = {
+		death="1371.1.1"
+	}
+}
+
+93750 = {
+	name="Sebestyen"
+	dynasty=12002
+	religion="catholic"
+	culture="hungarian"
+	father=93746
+	1330.1.1 = {
+		birth="1330.1.1"
+	}
+	1361.1.1 = {
+		death="1361.1.1"
+	}
+}
+
+93751 = {
+	name="Gyula"
+	dynasty=7378
+	religion="catholic"
+	culture="hungarian"
+	1175.1.1 = {
+		birth="1175.1.1"
+	}
+	1226.1.1 = {
+		death="1226.1.1"
+	}
+}
+
+93752 = {
+	name="László"
+	dynasty=7378
+	religion="catholic"
+	culture="hungarian"
+	father=93751
+	1205.1.1 = {
+		birth="1205.1.1"
+	}
+	1276.1.1 = {
+		death="1276.1.1"
+	}
+}
+
+93753 = {
+	name="Gyula"
+	dynasty=7378
+	religion="catholic"
+	culture="hungarian"
+	father=93751
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1233.1.1 = {
+		death="1233.1.1"
+	}
+}
+
+93754 = {
+	name="László"
+	dynasty=7378
+	religion="catholic"
+	culture="hungarian"
+	father=93752
+	1250.1.1 = {
+		birth="1250.1.1"
+	}
+	1315.1.1 = {
+		death="1315.1.1"
+	}
+}
+
+93755 = {
+	name="Móricz"
+	dynasty=19057
+	religion="catholic"
+	culture="hungarian"
+	father=93756
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1269.1.1 = {
+		death="1269.1.1"
+	}
+}
+
+93756 = {
+	name="Móricz"
+	dynasty=19057
+	religion="catholic"
+	culture="hungarian"
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1250.1.1 = {
+		death="1250.1.1"
+	}
+}
+
+93757 = {
+	name="Sámuel"
+	# placeholder
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=20376
+	1085.1.1 = {
+		birth="1085.1.1"
+	}
+	1145.1.1 = {
+		death="1145.1.1"
+	}
+}
+
+93758 = {
+	name="János"
+	# placeholder
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=93757
+	1115.1.1 = {
+		birth="1115.1.1"
+	}
+	1180.1.1 = {
+		death="1180.1.1"
+	}
+}
+
+93759 = {
+	name="Domoszló"
+	# placeholder
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=93758
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1210.1.1 = {
+		death="1210.1.1"
+	}
+}
+
+93760 = {
+	name="Géza"
+	# placeholder
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=93759
+	1180.1.1 = {
+		birth="1180.1.1"
+	}
+	1240.1.1 = {
+		death="1240.1.1"
+	}
+}
+
+93761 = {
+	name="Dávid"
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=93760
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1260.1.1 = {
+		death="1260.1.1"
+	}
+}
+
+93762 = {
+	name="Amadé"
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=93761
+	1240.1.1 = {
+		birth="1240.1.1"
+	}
+	1311.9.5 = {
+		death="1311.9.5"
+	}
+}
+
+93763 = {
+	name="Fintá"
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=93761
+	1245.1.1 = {
+		birth="1245.1.1"
+	}
+	1311.9.5 = {
+		death="1311.9.5"
+	}
+}
+
+93765 = {
+	name="Hencz"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93764
+	1140.1.1 = {
+		birth="1140.1.1"
+	}
+	1196.1.1 = {
+		death="1196.1.1"
+	}
+}
+
+93766 = {
+	name="Mihály"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93765
+	1165.1.1 = {
+		birth="1165.1.1"
+	}
+	1212.1.1 = {
+		death="1212.1.1"
+	}
+}
+
+93767 = {
+	name="Henrik"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93765
+	1175.1.1 = {
+		birth="1175.1.1"
+	}
+	1237.1.1 = {
+		death="1237.1.1"
+	}
+}
+
+93768 = {
+	name="Henrik"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93767
+	1210.1.1 = {
+		birth="1210.1.1"
+	}
+	1274.1.1 = {
+		death="1274.1.1"
+	}
+}
+
+93769 = {
+	name="Miklós"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93768
+	1240.1.1 = {
+		birth="1240.1.1"
+	}
+	1299.1.1 = {
+		death="1299.1.1"
+	}
+}
+
+93770 = {
+	name="János"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93768
+	1245.1.1 = {
+		birth="1245.1.1"
+	}
+	1308.5.4 = {
+		death="1308.5.4"
+	}
+}
+
+93771 = {
+	name="Péter"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93768
+	1250.1.1 = {
+		birth="1250.1.1"
+	}
+	1289.1.1 = {
+		death="1289.1.1"
+	}
+}
+
+93772 = {
+	name="Miklós"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93769
+	1275.1.1 = {
+		birth="1275.1.1"
+	}
+	1332.1.1 = {
+		death="1332.1.1"
+	}
+}
+
+93773 = {
+	name="János"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93769
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1330.1.1 = {
+		death="1330.1.1"
+	}
+}
+
+93774 = {
+	name="János"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93772
+	1300.1.1 = {
+		birth="1300.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+93775 = {
+	name="László"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93772
+	1302.1.1 = {
+		birth="1302.1.1"
+	}
+	1336.1.1 = {
+		death="1336.1.1"
+	}
+}
+
+93776 = {
+	name="Henrik"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93772
+	1310.1.1 = {
+		birth="1310.1.1"
+	}
+	1376.1.1 = {
+		death="1376.1.1"
+	}
+}
+
+93777 = {
+	name="Miklós"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93776
+	1330.1.1 = {
+		birth="1330.1.1"
+	}
+	1360.1.1 = {
+		death="1360.1.1"
+	}
+}
+
+93778 = {
+	name="András"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93776
+	1335.1.1 = {
+		birth="1335.1.1"
+	}
+	1423.1.1 = {
+		death="1423.1.1"
+	}
+}
+
+93779 = {
+	name="János"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=470150
+	1295.1.1 = {
+		birth="1295.1.1"
+	}
+	1327.1.1 = {
+		death="1327.1.1"
+	}
+}
+
+93780 = {
+	name="Miklós"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93779
+	1315.1.1 = {
+		birth="1315.1.1"
+	}
+	1358.1.1 = {
+		death="1358.1.1"
+	}
+}
+
+93781 = {
+	name="Péter"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93779
+	1317.1.1 = {
+		birth="1317.1.1"
+	}
+	1358.1.1 = {
+		death="1358.1.1"
+	}
+}
+
+93782 = {
+	name="Henrik"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93779
+	1319.1.1 = {
+		birth="1319.1.1"
+	}
+	1358.1.1 = {
+		death="1358.1.1"
+	}
+}
+
+93783 = {
+	name="Miklós"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=470150
+	1302.1.1 = {
+		birth="1302.1.1"
+	}
+	1336.1.1 = {
+		death="1336.1.1"
+	}
+}
+
+93784 = {
+	name="Péter"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=470151
+	mother=470152
+	1330.1.1 = {
+		birth="1330.1.1"
+	}
+	1405.1.1 = {
+		death="1405.1.1"
+	}
+}
+
+93785 = {
+	name="Gergely"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93770
+	1265.1.1 = {
+		birth="1265.1.1"
+	}
+	1297.1.1 = {
+		death="1297.1.1"
+	}
+}
+
+93786 = {
+	name="János"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93770
+	1270.1.1 = {
+		birth="1270.1.1"
+	}
+	1333.1.1 = {
+		death="1333.1.1"
+	}
+}
+
+93787 = {
+	name="Miklós"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93785
+	1285.1.1 = {
+		birth="1285.1.1"
+	}
+	1314.1.1 = {
+		death="1314.1.1"
+	}
+}
+
+93788 = {
+	name="András"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93785
+	1290.1.1 = {
+		birth="1290.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+93789 = {
+	name="Tamás" #real name unknown
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	1190.1.1 = {
+		birth="1190.1.1"
+	}
+	1240.1.1 = {
+		death="1240.1.1"
+	}
+}
+
+93790 = {
+	name="Barnabás"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93789
+	1210.1.1 = {
+		birth="1210.1.1"
+	}
+	1279.1.1 = {
+		death="1279.1.1"
+	}
+}
+
+93791 = {
+	name="György"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93789
+	1215.1.1 = {
+		birth="1215.1.1"
+	}
+	1265.1.1 = {
+		death="1265.1.1"
+	}
+}
+
+93792 = {
+	name="Tamás"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93790
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1295.1.1 = {
+		death="1295.1.1"
+	}
+}
+
+93793 = {
+	name="János"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93790
+	1232.1.1 = {
+		birth="1232.1.1"
+	}
+	1279.1.1 = {
+		death="1279.1.1"
+	}
+}
+
+93794 = {
+	name="Loránd"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93792
+	1250.1.1 = {
+		birth="1250.1.1"
+	}
+	1301.1.1 = {
+		death="1301.1.1"
+	}
+}
+
+93795 = {
+	name="István"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93792
+	1255.1.1 = {
+		birth="1255.1.1"
+	}
+	1294.1.1 = {
+		death="1294.1.1"
+	}
+}
+
+93796 = {
+	name="Jakab"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93792
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1325.1.1 = {
+		death="1325.1.1"
+	}
+}
+
+93797 = {
+	name="László"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93792
+	1262.1.1 = {
+		birth="1262.1.1"
+	}
+	1307.1.1 = {
+		death="1307.1.1"
+	}
+}
+
+93798 = {
+	name="Beke"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93792
+	1264.1.1 = {
+		birth="1264.1.1"
+	}
+	1326.1.1 = {
+		death="1326.1.1"
+	}
+}
+
+93799 = {
+	name="János"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93792
+	1266.1.1 = {
+		birth="1266.1.1"
+	}
+	1304.1.1 = {
+		death="1304.1.1"
+	}
+}
+
+93800 = {
+	name="István"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93794
+	1275.1.1 = {
+		birth="1275.1.1"
+	}
+	1337.1.1 = {
+		death="1337.1.1"
+	}
+}
+
+93801 = {
+	name="János"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93794
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1337.1.1 = {
+		death="1337.1.1"
+	}
+}
+
+93802 = {
+	name="László"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93794
+	1285.1.1 = {
+		birth="1285.1.1"
+	}
+	1357.1.1 = {
+		death="1357.1.1"
+	}
+}
+
+93803 = {
+	name="István"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93795
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1334.1.1 = {
+		death="1334.1.1"
+	}
+}
+
+93804 = {
+	name="István"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93795
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1334.1.1 = {
+		death="1334.1.1"
+	}
+}
+
+93805 = {
+	name="Bekcs"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93796
+	1285.1.1 = {
+		birth="1285.1.1"
+	}
+	1319.1.1 = {
+		death="1319.1.1"
+	}
+}
+
+159135 = {
+	name="Zoltán"
+	dynasty=708
+	religion="tengri_pagan"
+	culture="hungarian"
+	father=159136
+	880.1.2={
+		birth="880.1.2"
+	}
+	955.1.2={
+		death="955.1.2"
+	}
+}
+
+159136 = {
+	name="Árpád"
+	dynasty=708
+	religion="tengri_pagan"
+	culture="hungarian"
+	father=159137
+	martial=8
+	trait=ambitious
+	trait=strong
+	trait=just
+	trait=diligent
+	trait=brilliant_strategist
+	trait=flanker
+	845.1.1={
+		birth = yes
+	}
+	907.1.1={
+		death = yes
+	}
+}
+
+159137 = {
+	name="Álmos" # Ruler of the Magyars in 845
+	dynasty=708
+	religion="tengri_pagan"
+	culture="hungarian"
+	father=159138
+	mother=159139
+	martial=8
+	diplomacy=7
+	trait=ambitious
+	trait=gregarious
+	trait=just
+	trait=patient
+	trait=brilliant_strategist
+	trait=inspiring_leader
+	
+	810.1.1 = {
+		birth = yes
+	}
+	
+	867.1.1 = {
+		# Boost the initial strength of the Magyars
+		effect = {
+			spawn_unit = {
+				province = 544 # Korsun
+				owner = ROOT
+				leader = ROOT
+				troops = {
+					light_infantry = { 1626 1626 }
+					heavy_infantry = { 75 75 }
+					archers = { 325 325 }
+				}
+				attrition = 0.5
+                                earmark = start_troops
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 23
+				attributes = {
+					martial = 6
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				spawn_unit = {
+					province = 544 # Korsun
+					owner = ROOT
+					leader = THIS
+					troops = {
+						light_infantry = { 1626 1626 }
+						heavy_infantry = { 75 75 }
+						archers = { 325 325 }
+					}
+					attrition = 0.5
+                                        earmark = start_troops
+				}
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 27
+				attributes = {
+					martial = 6
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				spawn_unit = {
+					province = 544 # Korsun
+					owner = ROOT
+					leader = THIS
+					troops = {
+						light_infantry = { 1626 1626 }
+						heavy_infantry = { 75 75 }
+						archers = { 325 325 }
+					}
+					attrition = 0.5
+                                        earmark = start_troops
+				}
+			}
+		}
+	}
+	
+	895.1.1={
+		death = yes
+	}
+}
+#modified, and relocated
+159139 = { # wtf????????????????????????????? .
+	name="Emese"
+	female=yes
+	dynasty=1029005
+	religion="tengri_pagan"
+	culture="bashkir" 
+	father=159140 
+	775.1.2={
+		birth = yes
+	}
+	800.1.1={
+		add_spouse=159138
+	}
+	855.1.2={
+		death="855.1.2"
+	}
+}
+
+159140 = { # wtf????????????????????????????? you got to be kidding paradox, why the #%¤& make him Cuman? might aswell have made him Chinese or Mongol.
+	name="Önedbelia"
+	dynasty=1029005
+	religion="tengri_pagan"
+	culture="bashkir"
+	745.1.2={
+		birth = yes
+	}
+	815.1.2={
+		death = yes
+	}
+}
+
+159138 = { 
+	name="Ügyek"
+	dynasty=591 #?
+	religion="tengri_pagan"
+	culture="bolghar" #? 
+	father=159131
+	773.2.2={
+		birth="773.2.2"
+	}
+	800.1.1={
+		add_spouse=159139
+	}
+	845.1.2={
+		death = yes
+	}
+}
+###
+163168 = {
+	name="Linütika"
+	dynasty=708
+	religion="tengri_pagan"
+	culture="hungarian"
+	father=159136
+	861.1.1={
+		birth="861.1.1"
+	}
+	906.1.1={
+		death="906.1.1"
+	}
+}
+
+163169 = {
+	name="Tarkatzus"
+	dynasty=708
+	religion="tengri_pagan"
+	culture="hungarian"
+	father=159136
+	864.1.1={
+		birth="864.1.1"
+	}
+	920.1.1={
+		death="920.1.1"
+	}
+}
+146214 = {
+	name="Jenö"
+	dynasty=1022386
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	741.1.1={
+		birth = yes
+	}
+	803.1.1={
+		death = yes
+	}
+}
+
+146215 = {
+	name="Dezsõ"
+	dynasty=1022386
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146214
+	758.1.1={
+		birth = yes
+	}
+	819.1.1={
+		death = yes
+	}
+}
+
+146216 = {
+	name="Kér"
+	dynasty=1022387
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	742.1.1={
+		birth = yes
+	}
+	804.1.1={
+		death = yes
+	}
+}
+
+146217 = {
+	name="Elek"
+	dynasty=1022387
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146216
+	759.1.1={
+		birth = yes
+	}
+	820.1.1={
+		death = yes
+	}
+}
+
+146218 = {
+	name="Keszi"
+	dynasty=1022388
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	743.1.1={
+		birth = yes
+	}
+	805.1.1={
+		death = yes
+	}
+}
+
+146219 = {
+	name="Dömötör"
+	dynasty=1022388
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146218
+	760.1.1={
+		birth = yes
+	}
+	821.1.1={
+		death = yes
+	}
+}
+
+146220 = {
+	name="Kürt"
+	dynasty=1022389
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	744.1.1={
+		birth = yes
+	}
+	806.1.1={
+		death = yes
+	}
+}
+
+146221 = {
+	name="Gergely"
+	dynasty=1022389
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146220
+	761.1.1={
+		birth = yes
+	}
+	822.1.1={
+		death = yes
+	}
+}
+
+146222 = {
+	name="Gyarmat"
+	dynasty=1022390
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	745.1.1={
+		birth = yes
+	}
+	807.1.1={
+		death = yes
+	}
+}
+
+146223 = {
+	name="Attila"
+	dynasty=1022390
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146222
+	762.1.1={
+		birth = yes
+	}
+	823.1.1={
+		death = yes
+	}
+}
+
+146224 = {
+	name="Megyer"
+	dynasty=1022391
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	746.1.1={
+		birth = yes
+	}
+	808.1.1={
+		death = yes
+	}
+}
+
+146225 = {
+	name="Tivadar"
+	dynasty=1022391
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146224
+	763.1.1={
+		birth = yes
+	}
+	824.1.1={
+		death = yes
+	}
+}
+
+146226 = {
+	name="Nyék"
+	dynasty=1022392
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	747.1.1={
+		birth = yes
+	}
+	809.1.1={
+		death = yes
+	}
+}
+
+146227 = {
+	name="Zsolt"
+	dynasty=1022392
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146226
+	764.1.1={
+		birth = yes
+	}
+	825.1.1={
+		death = yes
+	}
+}
+
+146228 = {
+	name="Tarján"
+	dynasty=1022393
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	748.1.1={
+		birth = yes
+	}
+	810.1.1={
+		death = yes
+	}
+}
+
+146229 = {
+	name="Tibor"
+	dynasty=1022393
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146228
+	765.1.1={
+		birth = yes
+	}
+	826.1.1={
+		death = yes
+	}
+}
+
+146230 = {
+	name="Tétény"
+	dynasty=1022386
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146215
+	783.1.1={
+		birth = yes
+	}
+	845.1.1={
+		death = yes
+	}
+}
+
+146231 = {
+	name="Töhötöm"
+	dynasty=1022386 # Jenö
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146230
+	809.1.1={
+		birth = yes
+	}
+	873.1.1={
+		death = yes
+	}
+}
+194365 = {
+	name="Géza"
+	religion=tengri_pagan
+	culture=hungarian
+	father=6847
+	840.1.1={
+		birth = yes
+	}
+	897.1.1={
+		death = yes
+	}
+}
+194366 = {
+	name="Ibolya"
+	female = yes
+	religion=tengri_pagan
+	culture=hungarian
+	father=6847
+	845.1.1={
+		birth = yes
+	}
+	897.1.1={
+		death = yes
+	}
+}
+194345 = {
+	name="Elek"
+	dynasty=1022386
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146214
+	760.1.1={
+		birth = yes
+	}
+	819.1.1={
+		death = yes
+	}
+}
+194367 = {
+	name="Csaba"
+	dynasty=1022386
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146231
+	840.1.1={
+		birth = yes
+	}
+	890.1.1={
+		death = yes
+	}
+}
+194368 = {
+	name="Hajnal"
+	female = yes
+	dynasty=1022386
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146231
+	845.1.1={
+		birth = yes
+	}
+	890.1.1={
+		death = yes
+	}
+}

--- a/EMF+Vanilla/history/characters/hungarian.txt
+++ b/EMF+Vanilla/history/characters/hungarian.txt
@@ -1,0 +1,9899 @@
+1621 = {
+	name="Márton"
+	# AKA: Marton
+	dynasty=101570
+	martial=5
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=4409
+	1027.1.1 = {
+		birth=yes
+	}
+	1049.1.1 = {
+		add_spouse=4411
+	}
+	1080.1.1 = {
+		death=yes
+	}
+}
+
+6847 = {
+	name="Csák"
+	religion=tengri_pagan
+	culture=hungarian
+	820.1.1={
+		birth=yes
+	}
+	897.1.1={
+		death=yes
+	}
+}
+
+194365 = {
+	name="Géza"
+	religion=tengri_pagan
+	culture=hungarian
+	father=6847
+	840.1.1={
+		birth=yes
+	}
+	897.1.1={
+		death=yes
+	}
+}
+194366 = {
+	name="Ibolya"
+	female = yes
+	religion=tengri_pagan
+	culture=hungarian
+	father=6847
+	845.1.1={
+		birth=yes
+	}
+	897.1.1={
+		death=yes
+	}
+}
+
+6848 = {
+	name="Gyula"
+	religion=tengri_pagan
+	culture=hungarian
+	841.1.1={
+		birth=yes
+	}
+	895.1.1={
+		death=yes
+	}
+}
+
+20356 = {
+	name="György"
+	dynasty=19010
+	martial=8
+	diplomacy=7
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="tough_soldier"
+	1020.1.1 = {
+		birth="1020.1.1"
+	}
+	1045.1.1 = {
+		add_spouse=4434
+	}
+	1083.1.1 = {
+		death="1083.1.1"
+	}
+}
+
+20360 = {
+	name="Ottó"
+	# AKA: Otto
+	dynasty=101568
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="skilled_tactician"
+	1012.1.1 = {
+		birth="1012.1.1"
+	}
+	1038.1.1 = {
+		add_spouse=4389
+	}
+	1082.1.1 = {
+		death="1082.1.1"
+	}
+}
+
+20362 = {
+	name="Gút"
+	# AKA: Gut
+	dynasty=19052
+	martial=8
+	diplomacy=6
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="amateurish_plotter"
+	father=20357
+	1005.1.1 = {
+		birth="1005.1.1"
+	}
+	1065.1.1 = {
+		death="1065.1.1"
+	}
+}
+
+20363 = {
+	name="Keled"
+	dynasty=19052
+	martial=8
+	diplomacy=5
+	intrigue=7
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="deceitful"
+	trait="grey_eminence"
+	father=20357
+	1010.1.1 = {
+		birth="1010.1.1"
+	}
+	1033.1.2 = {
+		add_spouse=491
+	}
+	1068.1.1 = {
+		death="1068.1.1"
+	}
+}
+
+20364 = {
+	name="Elek"
+	dynasty=101566
+	martial=6
+	diplomacy=8
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="kind"
+	trait="tough_soldier"
+	father=4379
+	1024.1.1 = {
+		birth="1024.1.1"
+	}
+	1050.1.1 = {
+		add_spouse=4384
+	}
+	1083.1.1 = {
+		death="1083.1.1"
+	}
+}
+
+20365 = {
+	name="Máté"
+	# AKA: Mate
+	dynasty=101565
+	martial=8
+	diplomacy=4
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="clubfooted"
+	trait="scholarly_theologian"
+	1023.1.1 = {
+		birth="1023.1.1"
+	}
+	1040.1.1 = {
+		add_spouse=4365
+	}
+	1078.1.1 = {
+		death="1078.1.1"
+	}
+}
+
+20366 = {
+	name="Péter"
+	dynasty=19000
+	martial=5
+	diplomacy=7
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="flamboyant_schemer"
+	father=20371
+	mother=499
+	1017.1.1 = {
+		birth="1017.1.1"
+	}
+	1040.1.1 = {
+		add_spouse=20375
+	}
+	1080.1.1 = {
+		death="1080.1.1"
+	}
+}
+
+20367 = {
+	name="Ince"
+	dynasty=101569
+	martial=7
+	diplomacy=6
+	intrigue=7
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="underhanded_rogue"
+	father=4399
+	1047.1.1 = {
+		birth="1047.1.1"
+	}
+	1095.1.1 = {
+		death="1095.1.1"
+	}
+}
+
+20368 = {
+	name="Lampert"
+	dynasty=708
+	martial=4
+	diplomacy=4
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="underhanded_rogue"
+	father=470
+	mother=763
+	1051.1.1 = {
+		birth="1051.1.1"
+	}
+	1095.1.1 = {
+		death="1095.1.1"
+	}
+}
+
+20369 = {
+	name="Lampert"
+	dynasty=19053
+	martial=4
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="stutter"
+	trait="tough_soldier"
+	father=4429
+	1055.1.1 = {
+		birth="1055.1.1"
+	}
+	1132.1.1 = {
+		death="1132.1.1"
+	}
+}
+
+20370 = {
+	name="Zsófia"
+	# AKA: Zsofia
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=5
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="craven"
+	trait="charismatic_negotiator"
+	father=472
+	mother=479
+	1064.1.1 = {
+		birth="1064.1.1"
+	}
+	1120.1.1 = {
+		death="1120.1.1"
+	}
+}
+
+20371 = {
+	name="Sámuel"
+	# AKA: Samuel
+	dynasty=19000
+	martial=6
+	diplomacy=4
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="greedy"
+	trait="tough_soldier"
+	990.1.2 = {
+		birth="990.1.2"
+	}
+	1010.1.1 = {
+		add_spouse=499
+	}
+	1044.7.1 = {
+		death="1044.7.1"
+	}
+}
+
+20372 = {
+	name="Belenik"
+	dynasty=101563
+	martial=5
+	diplomacy=8
+	intrigue=6
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="underhanded_rogue"
+	1024.1.1 = {
+		birth="1024.1.1"
+	}
+	1048.1.1 = {
+		add_spouse=4444
+	}
+	1081.1.1 = {
+		death="1081.1.1"
+	}
+}
+
+20373 = {
+	name="Mihály"
+	# AKA: Mihaly
+	dynasty=101564
+	martial=4
+	diplomacy=5
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="charismatic_negotiator"
+	1039.1.1 = {
+		birth="1039.1.1"
+	}
+	1064.1.1 = {
+		add_spouse=4366
+	}
+	1066.1.1 = {
+	employer=20365
+	}
+	1087.1.1 = {
+		death="1087.1.1"
+	}
+}
+
+20374 = {
+	name="Ilya"
+	dynasty=101573
+	martial=5
+	diplomacy=4
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="tough_soldier"
+	1031.1.1 = {
+		birth="1031.1.1"
+	}
+	1066.1.1 = {
+	employer=476
+	}
+	1083.1.1 = {
+		death="1083.1.1"
+	}
+}
+
+20375 = {
+	name="Emese"
+	female=yes
+	dynasty=180
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="detached_priest"
+	1025.1.1 = {
+		birth="1025.1.1"
+	}
+	1086.1.1 = {
+		death="1086.1.1"
+	}
+}
+
+20376 = {
+	name="Mihály"
+	# AKA: Mihaly
+	dynasty=19000
+	martial=7
+	diplomacy=4
+	intrigue=7
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="charitable"
+	trait="tough_soldier"
+	father=20366
+	mother=20375
+	1042.1.1 = {
+		birth="1042.1.1"
+	}
+	1102.1.1 = {
+		death="1102.1.1"
+	}
+}
+
+20377 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19000
+	martial=4
+	diplomacy=5
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="honest"
+	trait="diligent"
+	trait="martial_cleric"
+	father=20366
+	mother=20375
+	1045.1.1 = {
+		birth="1045.1.1"
+	}
+	1099.1.1 = {
+		death="1099.1.1"
+	}
+}
+
+20378 = {
+	name="Keled"
+	dynasty=19052
+	martial=9
+	diplomacy=5
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="cynical"
+	trait="misguided_warrior"
+	father=20363
+	mother=491
+	1034.1.1 = {
+		birth="1034.1.1"
+	}
+	1056.1.2 = {
+		add_spouse=4363
+	}
+	1086.1.1 = {
+		death="1086.1.1"
+	}
+}
+
+20379 = {
+	name="Bény"
+	# AKA: Beny
+	dynasty=19052
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="underhanded_rogue"
+	father=20363
+	mother=491
+	1036.1.1 = {
+		birth="1036.1.1"
+	}
+	1096.1.1 = {
+		death="1096.1.1"
+	}
+}
+
+219001 = {
+	name="Almos"
+	dynasty=100442
+	martial=4
+	diplomacy=7
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="skilled_tactician"
+	1150.1.1 = {
+		birth=yes
+	}
+	1200.1.1 = {
+		death=yes
+	}
+}
+
+219003 = {
+	name="Tamás"
+	dynasty=100444
+	martial=8
+	diplomacy=4
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="wroth"
+	trait="flamboyant_schemer"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219004 = {
+	name="Donát"
+	# AKA: Donat
+	dynasty=100445
+	martial=5
+	diplomacy=7
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="scholarly_theologian"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219005 = {
+	name="Gellért"
+	# AKA: Gellert
+	dynasty=100450
+	martial=6
+	diplomacy=8
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=93654
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219006 = {
+	name="Kornél"
+	# AKA: Kornel
+	dynasty=100451
+	martial=6
+	diplomacy=5
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="proud"
+	trait="skilled_tactician"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219007 = {
+	name="Bernát"
+	# AKA: Bernat
+	dynasty=100452
+	martial=4
+	diplomacy=5
+	intrigue=8
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="amateurish_plotter"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219008 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=100453
+	martial=7
+	diplomacy=6
+	intrigue=8
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="underhanded_rogue"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219009 = {
+	name="Móric"
+	# AKA: Moric
+	dynasty=100454
+	martial=7
+	diplomacy=5
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="cynical"
+	trait="temperate"
+	trait="amateurish_plotter"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219010 = {
+	name="Ádárn"
+	# AKA: adarn
+	dynasty=100460
+	martial=4
+	diplomacy=4
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219011 = {
+	name="Márton"
+	# AKA: Marton
+	#dynasty=100462
+	martial=7
+	diplomacy=6
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="proud"
+	trait="honest"
+	trait="scholarly_theologian"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219013 = {
+	name="János"
+	# AKA: Janos
+	dynasty=100517
+	martial=6
+	diplomacy=7
+	intrigue=8
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="martial_cleric"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219014 = {
+	name="Gábriel"
+	# AKA: Gabriel
+	dynasty=100518
+	martial=5
+	diplomacy=8
+	intrigue=5
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219015 = {
+	name="Imre"
+	dynasty=100519
+	martial=6
+	diplomacy=4
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="greedy"
+	trait="tough_soldier"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219016 = {
+	name="Mátyás"
+	# AKA: Matyas
+	dynasty=100520
+	martial=7
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="brave"
+	trait="tough_soldier"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219017 = {
+	name="Móric"
+	# AKA: Moric
+	dynasty=100521
+	martial=7
+	diplomacy=8
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219018 = {
+	name="Ágoston"
+	# AKA: agoston
+	dynasty=100523
+	martial=4
+	diplomacy=8
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="craven"
+	trait="martial_cleric"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219019 = {
+	name="Elemér"
+	# AKA: Elemer
+	dynasty=100524
+	martial=5
+	diplomacy=8
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219020 = {
+	name="Bertalan"
+	dynasty=100525
+	martial=4
+	diplomacy=7
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="humble"
+	trait="cynical"
+	trait="amateurish_plotter"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219021 = {
+	name="Gáspár"
+	# AKA: Gaspar
+	dynasty=100533
+	martial=5
+	diplomacy=5
+	intrigue=7
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219022 = {
+	name="Gábor"
+	dynasty=100537
+	martial=5
+	diplomacy=7
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="fortune_builder"
+	father=93638
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219023 = {
+	name="Elek"
+	dynasty=100538
+	martial=5
+	diplomacy=7
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="greedy"
+	trait="flamboyant_schemer"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219024 = {
+	name="Konrád"
+	# AKA: Konrad
+	dynasty=100539
+	martial=6
+	diplomacy=8
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="slothful"
+	trait="gluttonous"
+	trait="tough_soldier"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219025 = {
+	name="Attila"
+	dynasty=100540
+	martial=4
+	diplomacy=4
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="greedy"
+	trait="craven"
+	trait="martial_cleric"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+219500 = {
+	name="Béla"
+	dynasty=708
+	martial=4
+	diplomacy=6
+	intrigue=8
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=219510
+	mother=222573
+	1148.1.1 = {
+		birth="1148.1.1"
+	}
+	1163.1.2 = {
+		add_spouse=213528
+	}
+	1163.6.19= {
+		add_claim = k_hungary
+		add_claim = k_croatia
+	}	
+	1169.1.2 = {
+		remove_spouse=213528
+	}
+	1172.1.2 = {
+		add_spouse=223593
+	}
+	1172.3.4= {
+		remove_claim = k_hungary
+		remove_claim = k_croatia
+	}
+	1186.1.2 = {
+		add_spouse=205515
+	}
+	1196.4.23 = {
+		death="1196.4.23"
+	}
+}
+
+219501 = {
+	name="Imre"
+	dynasty=708
+	martial=8
+	diplomacy=8
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=219500
+	mother=223593
+	1174.1.2 = {
+		birth="1174.1.2"
+	}
+	1198.1.2 = {
+		add_spouse=210503
+	}
+	1204.11.30 = {
+		death="1204.11.30"
+	}
+}
+
+219502 = {
+	name="András"
+	# AKA: Andras
+	dynasty=708
+	martial=7
+	diplomacy=5
+	intrigue=8
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="honest"
+	trait="tough_soldier"
+	father=219500
+	mother=223593
+	1176.1.2 = {
+		birth="1176.1.2"
+	}
+	1202.1.2 = {
+		add_spouse=212946
+	}
+	1215.2.2 = {
+		add_spouse=98024
+	}
+	1234.5.14 = {
+		add_spouse=98025
+	}
+	1235.9.21 = {
+		death="1235.9.21"
+	}
+}
+
+219503 = {
+	name="Konstancia"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=4
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="cynical"
+	trait="martial_cleric"
+	father=219500
+	mother=223593
+	1180.1.2 = {
+		birth="1180.1.2"
+	}
+	1240.12.6 = {
+		death="1240.12.6"
+	}
+}
+
+219504 = {
+	name="Erzebet"
+	female=yes
+	dynasty=708
+	martial=8
+	diplomacy=8
+	intrigue=8
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="martial_cleric"
+	father=219500
+	mother=223593
+	1178.1.2 = {
+		birth="1178.1.2"
+	}
+	1228.1.2 = {
+		death="1228.1.2"
+	}
+}
+
+219505 = {
+	name="Erzebet"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=7
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="temperate"
+	trait="flamboyant_schemer"
+	father=219530
+	mother=218511
+	1128.1.2 = {
+		birth="1128.1.2"
+	}
+	1154.7.21 = {
+		death="1154.7.21"
+	}
+}
+
+219510 = {
+	name="Géza"
+	# AKA: Geza
+	dynasty=708
+	martial=6
+	diplomacy=7
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="kind"
+	trait="brave"
+	trait="underhanded_rogue"
+	father=219530
+	mother=218511
+	1130.1.2 = {
+		birth="1130.1.2"
+	}
+	1141.2.13 = {
+	capital=k_hungary
+	}
+	#1146.1.2 = {
+	#	add_spouse=222573
+	#}
+	1162.5.31 = {
+		death="1162.5.31"
+	}
+}
+
+219511 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=708
+	martial=8
+	diplomacy=7
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="craven"
+	trait="martial_cleric"
+	father=219510
+	mother=222573
+	1147.7.2 = {
+		birth="1147.7.2"
+	}
+	1167.1.2 = {
+		add_spouse=98022
+	}
+	1168.1.2 = {
+	remove_spouse=98022
+	}
+	1168.5.2 = {
+		add_spouse=212542
+	}
+	1172.3.4 = {
+		death="1172.3.4"
+	}
+}
+
+219512 = {
+	name="Erzsebeth"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=7
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="deceitful"
+	trait="flamboyant_schemer"
+	father=219510
+	mother=222573
+	1144.1.2 = {
+		birth="1144.1.2"
+	}
+	1194.1.2 = {
+		death="1194.1.2"
+	}
+}
+
+219515 = {
+	name="Margit"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=6
+	intrigue=8
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="arbitrary"
+	trait="harelip"
+	trait="martial_cleric"
+	father=219500
+	mother=223593
+	1175.1.2 = {
+		birth="1175.1.2"
+	}
+	1229.3.29 = {
+		death="1229.3.29"
+	}
+}
+
+219517 = {
+	name="Geza"
+	dynasty=708
+	martial=8
+	diplomacy=7
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="inbred"
+	trait="flamboyant_schemer"
+	father=219510
+	mother=222573
+	1150.1.2 = {
+		birth="1150.1.2"
+	}
+	1200.1.2 = {
+		death="1200.1.2"
+	}
+}
+
+219518 = {
+	name="Helena"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="martial_cleric"
+	father=219510
+	mother=222573
+	1158.1.2 = {
+		birth="1158.1.2"
+	}
+	1208.1.2 = {
+		death="1208.1.2"
+	}
+}
+
+219519 = {
+	name="Margit"
+	female=yes
+	dynasty=708
+	martial=6
+	diplomacy=7
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="gluttonous"
+	trait="cynical"
+	trait="scholarly_theologian"
+	father=219510
+	mother=222573
+	1162.1.2 = {
+		birth="1162.1.2"
+	}
+	1212.1.2 = {
+		death="1212.1.2"
+	}
+}
+
+219525 = {
+	name="Erzsebet"
+	female=yes
+	dynasty=708
+	martial=7
+	diplomacy=7
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="cynical"
+	trait="underhanded_rogue"
+	father=480
+	mother=98008
+	1094.1.2 = {
+		birth="1094.1.2"
+	}
+	1153.1.2 = {
+		death="1153.1.2"
+	}
+}
+
+219530 = {
+	name="Béla"
+	# AKA: Bela
+	dynasty=708
+	martial=4
+	diplomacy=8
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="cynical"
+	trait="maimed"
+	trait="scholarly_theologian"
+	father=219531
+	mother=219532
+	1109.1.2 = {
+		birth="1109.1.2"
+	}
+	1127.4.28 = {
+		add_spouse=218511
+	}
+	1131.4.2 = {
+	capital=k_hungary
+	}
+	1141.2.13 = {
+		death="1141.2.13"
+	}
+}
+
+219531 = {
+	name="Almos"
+	dynasty=708
+	martial=5
+	diplomacy=5
+	intrigue=8
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="wroth"
+	trait="charismatic_negotiator"
+	father=472
+	mother=479
+	1074.1.2 = {
+		birth="1074.1.2"
+	}
+	1104.8.21 = {
+		add_spouse=219532
+	}
+	1129.1.3 = {
+		death="1129.1.3"
+	}
+}
+
+219533 = {
+	name="Adelaida"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=4
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="scholarly_theologian"
+	father=219531
+	mother=219532
+	1105.1.2 = {
+		birth="1105.1.2"
+	}
+	1141.1.14 = {
+		death="1141.1.14"
+	}
+}
+
+219550 = {
+	name="Andras"
+	dynasty=180
+	martial=8
+	diplomacy=4
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="martial_cleric"
+	1154.1.2 = {
+		birth="1154.1.2"
+	}
+	1204.1.2 = {
+		death="1204.1.2"
+	}
+}
+
+231060 = {
+	name="Eirene"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=8
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="humble"
+	trait="scholarly_theologian"
+	father=474
+	mother=1399
+	1088.1.2 = {
+		birth="1088.1.2"
+	}
+	1134.1.14 = {
+		death="1134.1.14"
+	}
+}
+
+231065 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=708
+	martial=8
+	diplomacy=5
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="just"
+	trait="proud"
+	trait="skilled_tactician"
+	father=480
+	mother=98008
+	1101.1.2 = {
+		birth="1101.1.2"
+	}
+	1116.2.3 = {
+		capital=k_hungary
+	}
+	1120.1.2 = {
+		add_spouse=98013
+	}
+	1131.4.2 = {
+		death="1131.4.2"
+	}
+}
+
+232553 = {
+	name="Borisz-Konrád"
+	# AKA: Borisz
+	dynasty=708
+	martial=5
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="bastard"
+	trait="gregarious"
+	trait="greedy"
+	trait="misguided_warrior"
+	father=480
+	mother=98018
+	1113.1.2 = {
+		birth="1113.1.2"
+	}
+	1130.1.2 = {
+		add_spouse=232554
+	}
+	1156.1.2 = {
+		death="1156.1.2"
+	}
+}
+
+41200 = {
+	name="Mária"
+	# AKA: Maria
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="thrifty_clerk"
+	father=470
+	mother=763
+	1050.1.1 = {
+		birth="1050.1.1"
+	}
+	1066.1.1 = {
+	employer=474
+	}
+	1103.1.1 = {
+		death="1103.1.1"
+	}
+}
+
+41201 = {
+	name="Lanka"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	father=470
+	mother=763
+	1045.1.1 = {
+		birth="1045.1.1"
+	}
+	1095.6.18 = {
+		death="1095.6.18"
+	}
+}
+
+4358 = {
+	name="Álmos"
+	# AKA: Almos
+	dynasty=101563
+	martial=6
+	diplomacy=5
+	intrigue=8
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="just"
+	trait="fortune_builder"
+	father=20372
+	mother=4444
+	1049.1.1 = {
+		birth="1049.1.1"
+	}
+	1114.1.1 = {
+		death="1114.1.1"
+	}
+}
+
+4362 = {
+	name="Amália"
+	# AKA: Amalia
+	female=yes
+	dynasty=19030
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="elusive_shadow"
+	1039.1.1 = {
+		birth="1039.1.1"
+	}
+	1090.1.1 = {
+		death="1090.1.1"
+	}
+}
+
+4363 = {
+	name="Zsófia"
+	# AKA: Zsofia
+	female=yes
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="charismatic_negotiator"
+	1040.1.1 = {
+		birth="1040.1.1"
+	}
+	1095.1.1 = {
+		death="1095.1.1"
+	}
+}
+
+4365 = {
+	name="Jolán"
+	# AKA: Jolan
+	female=yes
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	1025.1.1 = {
+		birth="1025.1.1"
+	}
+	1078.1.1 = {
+		death="1078.1.1"
+	}
+}
+
+4366 = {
+	name="Mária"
+	# AKA: Maria
+	female=yes
+	dynasty=101565
+	martial=4
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="thrifty_clerk"
+	father=20365
+	mother=4365
+	1049.1.1 = {
+		birth="1049.1.1"
+	}
+	1109.1.1 = {
+		death="1109.1.1"
+	}
+}
+
+4371 = {
+	name="Domoszló"
+	# AKA: Domoszlo
+	dynasty=19000
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="honest"
+	trait="tough_soldier"
+	father=20371
+	mother=499
+	1022.1.1 = {
+		birth="1022.1.1"
+	}
+	1050.1.1 = {
+		add_spouse=4443
+	}
+	1070.1.1 = {
+		death="1070.1.1"
+	}
+}
+
+4373 = {
+	name="Orsolya"
+	female=yes
+	dynasty=19000
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=4371
+	mother=4443
+	1051.1.1 = {
+		birth="1051.1.1"
+	}
+	1109.1.1 = {
+		death="1109.1.1"
+	}
+}
+
+4374 = {
+	name="Ernyei"
+	dynasty=101572
+	martial=7
+	diplomacy=7
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="ambitious"
+	trait="mastermind_theologian"
+	1021.1.1 = {
+		birth="1021.1.1"
+	}
+	1063.12.1 = {
+		effect = {
+			give_job_title=job_spiritual
+		}
+	}
+	1080.1.1 = {
+		death="1080.1.1"
+	}
+}
+
+4375 = {
+	name="Vid"
+	dynasty=19052
+	martial=5
+	diplomacy=4
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="martial_cleric"
+	father=20378
+	mother=4363
+	1059.1.1 = {
+		birth="1059.1.1"
+	}
+	1093.1.1 = {
+		death="1093.1.1"
+	}
+}
+
+4376 = {
+	name="Márton"
+	# AKA: Marton
+	dynasty=19052
+	martial=5
+	diplomacy=5
+	intrigue=3
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=20378
+	mother=4363
+	1062.1.1 = {
+		birth="1062.1.1"
+	}
+	1125.1.1 = {
+		death="1125.1.1"
+	}
+}
+
+4377 = {
+	name="Lothár"
+	dynasty=19052
+	martial=6
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="bastard"
+	father=20378
+	mother=4363
+	1064.1.1 = {
+		birth="1064.1.1"
+	}
+	1115.1.1 = {
+		death="1115.1.1"
+	}
+}
+
+4378 = {
+	name="Doboka"
+	dynasty=101566
+	martial=7
+	diplomacy=8
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="gluttonous"
+	trait="brave"
+	trait="tough_soldier"
+	959.1.1 = {
+		birth="959.1.1"
+	}
+	1012.1.1 = {
+		death="1012.1.1"
+	}
+}
+
+4379 = {
+	name="Csanád"
+	dynasty=101566
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="chaste"
+	trait="skilled_tactician"
+	father=4378
+	988.1.1 = {
+		birth="988.1.1"
+	}
+	1031.1.1 = {
+		death="1031.1.1"
+	}
+}
+
+4383 = {
+	name="Csömör"
+	dynasty=101566
+	martial=5
+	diplomacy=6
+	intrigue=3
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="cynical"
+	trait="scholarly_theologian"
+	father=4379
+	1019.1.1 = {
+		birth="1019.1.1"
+	}
+	1057.1.1 = {
+		death="1057.1.1"
+	}
+}
+
+4384 = {
+	name="Erzsébet"
+	female=yes
+	martial=7
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="amateurish_plotter"
+	1031.1.1 = {
+		birth="1031.1.1"
+	}
+	1094.1.1 = {
+		death="1094.1.1"
+	}
+}
+
+4385 = {
+	name="Imre"
+	dynasty=101566
+	martial=4
+	diplomacy=5
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="slothful"
+	trait="indulgent_wastrel"
+	father=4383
+	1042.1.1 = {
+		birth="1042.1.1"
+	}
+	1098.1.1 = {
+		death="1098.1.1"
+	}
+}
+
+4386 = {
+	name="Pongrácz"
+	dynasty=101566
+	martial=6
+	diplomacy=5
+	intrigue=4
+	stewardship=2
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=20364
+	mother=4384
+	1055.1.1 = {
+		birth="1055.1.1"
+	}
+	1098.1.1 = {
+		death="1098.1.1"
+	}
+}
+
+4387 = {
+	name="Gyula"
+	dynasty=101566
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="martial_cleric"
+	father=20364
+	mother=4384
+	1056.1.1 = {
+		birth="1056.1.1"
+	}
+	1117.1.1 = {
+		death="1117.1.1"
+	}
+}
+
+4388 = {
+	name="Margit"
+	female=yes
+	dynasty=19052
+	martial=4
+	diplomacy=6
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="humble"
+	trait="flamboyant_schemer"
+	father=20363
+	mother=491
+	1037.1.1 = {
+		birth="1037.1.1"
+	}
+	1075.1.1 = {
+		death="1075.1.1"
+	}
+}
+
+4389 = {
+	name="Gizella"
+	dynasty=19019
+	female=yes
+	martial=6
+	diplomacy=5
+	intrigue=5
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="flamboyant_schemer"
+	1017.1.1 = {
+		birth="1017.1.1"
+	}
+	1063.1.1 = {
+		death="1063.1.1"
+	}
+}
+
+4397 = {
+	name="Imre"
+	dynasty=101568
+	martial=8
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="kind"
+	trait="naive_appeaser"
+	father=20360
+	mother=4389
+	1048.1.1 = {
+		birth="1048.1.1"
+	}
+	1102.1.1 = {
+		death="1102.1.1"
+	}
+}
+
+4398 = {
+	name="Judit"
+	female=yes
+	dynasty=101568
+	martial=5
+	diplomacy=6
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="thrifty_clerk"
+	father=20360
+	mother=4389
+	1048.1.1 = {
+		birth="1048.1.1"
+	}
+	1105.1.1 = {
+		death="1105.1.1"
+	}
+}
+
+4400 = {
+	name="Tamás"
+	dynasty=101569
+	martial=3
+	diplomacy=5
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="martial_cleric"
+	father=4399
+	1045.1.1 = {
+		birth="1045.1.1"
+	}
+	1100.1.1 = {
+		death="1100.1.1"
+	}
+}
+
+4401 = {
+	name="Ipoly"
+	dynasty=19052
+	martial=7
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="tough_soldier"
+	father=20362
+	1033.1.1 = {
+		birth="1033.1.1"
+	}
+	1057.1.1 = {
+		add_spouse=4404
+	}
+	1090.1.1 = {
+		death="1090.1.1"
+	}
+}
+
+4402 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19052
+	martial=3
+	diplomacy=6
+	intrigue=7
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="arbitrary"
+	trait="martial_cleric"
+	father=20362
+	1035.1.1 = {
+		birth="1035.1.1"
+	}
+	1108.1.1 = {
+		death="1108.1.1"
+	}
+}
+
+4404 = {
+	name="Ilona"
+	female=yes
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="grey_eminence"
+	1036.1.1 = {
+		birth="1036.1.1"
+	}
+	1085.1.1 = {
+		death="1085.1.1"
+	}
+}
+
+4405 = {
+	name="Gertrúd"
+	# AKA: Gertrud
+	female=yes
+	dynasty=19052
+	martial=8
+	diplomacy=6
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	father=4406
+	mother=4362
+	1059.1.1 = {
+		birth="1059.1.1"
+	}
+	1120.1.1 = {
+		death="1120.1.1"
+	}
+}
+
+4406 = {
+	name="Bény"
+	# AKA: Beny
+	dynasty=19052
+	martial=6
+	diplomacy=6
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="arbitrary"
+	trait="fortune_builder"
+	father=20362
+	1039.1.1 = {
+		birth="1039.1.1"
+	}
+	1055.1.1 = {
+		add_spouse=4362
+	}
+	1087.1.1 = {
+		death="1087.1.1"
+	}
+}
+
+4409 = {
+	name="Miska"
+	dynasty=101570
+	martial=8
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="tough_soldier"
+	father=4408
+	1001.1.1 = {
+		birth="1001.1.1"
+	}
+	1053.1.1 = {
+		death="1053.1.1"
+	}
+}
+
+4410 = {
+	name="Kupán"
+	# AKA: Kupan
+	dynasty=101570
+	martial=4
+	diplomacy=6
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	trait="proud"
+	father=4409
+	1034.1.1 = {
+		birth="1034.1.1"
+	}
+	1057.1.1 = {
+		add_spouse=4415
+	}
+	1084.1.2 = {
+		death="1084.1.2"
+	}
+}
+
+4411 = {
+	name="Katalin"
+	female=yes
+	dynasty=12003
+	martial=8
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="underhanded_rogue"
+	1028.1.1 = {
+		birth="1028.1.1"
+	}
+	1089.1.1 = {
+		death="1089.1.1"
+	}
+}
+
+4412 = {
+	name="Bátor Obus"
+	# AKA: Bator Obus
+	dynasty=101570
+	martial=8
+	diplomacy=4
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="tough_soldier"
+	father=1621
+	mother=4411
+	1046.1.1 = {
+		birth="1046.1.1"
+	}
+	1095.1.1 = {
+		death="1095.1.1"
+	}
+}
+
+4413 = {
+	name="Anna"
+	female=yes
+	dynasty=101570
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="charismatic_negotiator"
+	father=1621
+	mother=4411
+	1048.1.1 = {
+		birth="1048.1.1"
+	}
+	1109.1.1 = {
+		death="1109.1.1"
+	}
+}
+
+4414 = {
+	name="Margit"
+	female=yes
+	dynasty=101570
+	martial=2
+	diplomacy=5
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="slothful"
+	trait="indulgent_wastrel"
+	father=1621
+	mother=4411
+	1050.1.1 = {
+		birth="1050.1.1"
+	}
+	1111.1.1 = {
+		death="1111.1.1"
+	}
+}
+
+4425 = {
+	name="Katalin"
+	female=yes
+	dynasty=101570
+	martial=4
+	diplomacy=4
+	intrigue=3
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=4410
+	mother=4415
+	1060.1.1 = {
+		birth="1060.1.1"
+	}
+	1118.1.1 = {
+		death="1118.1.1"
+	}
+}
+
+4431 = {
+	name="Hartvik"
+	dynasty=19061
+	martial=4
+	diplomacy=7
+	intrigue=8
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="zealous"
+	trait="scholarly_theologian"
+	1033.1.1 = {
+		birth="1033.1.1"
+	}
+	1063.12.1 = {
+		effect = {
+			give_job_title=job_spiritual
+		}
+	}
+	1111.1.1 = {
+		death="1111.1.1"
+	}
+}
+
+4432 = {
+	name="Elõd"
+	dynasty=19010
+	martial=7
+	diplomacy=6
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="fortune_builder"
+	father=20356
+	mother=4434
+	1046.1.1 = {
+		birth="1046.1.1"
+	}
+	1098.1.1 = {
+		death="1098.1.1"
+	}
+}
+
+4433 = {
+	name="Szabolcs"
+	dynasty=19010
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="envious"
+	trait="underhanded_rogue"
+	father=20356
+	mother=4434
+	1048.1.1 = {
+		birth="1048.1.1"
+	}
+	1105.1.1 = {
+		death="1105.1.1"
+	}
+}
+
+4434 = {
+	name="Anna"
+	female=yes
+	martial=6
+	diplomacy=7
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="cynical"
+	trait="martial_cleric"
+	1024.1.1 = {
+		birth="1024.1.1"
+	}
+	1078.1.1 = {
+		death="1078.1.1"
+	}
+}
+
+4435 = {
+	name="Antal"
+	dynasty=101571
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="greedy"
+	trait="misguided_warrior"
+	father=4437
+	1042.1.1 = {
+		birth="1042.1.1"
+	}
+	1065.1.1 = {
+		add_spouse=4436
+	}
+	1087.1.1 = {
+		death="1087.1.1"
+	}
+}
+
+4436 = {
+	name="Borbála"
+	dynasty=19010
+	female=yes
+	martial=4
+	diplomacy=6
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="honest"
+	trait="naive_appeaser"
+	father=20356
+	mother=4434
+	1047.1.1 = {
+		birth="1047.1.1"
+	}
+	1107.1.1 = {
+		death="1107.1.1"
+	}
+}
+
+4437 = {
+	name="Ete"
+	dynasty=101571
+	martial=7
+	diplomacy=7
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="underhanded_rogue"
+	1018.1.1 = {
+		birth="1018.1.1"
+	}
+	1061.1.1 = {
+		death="1061.1.1"
+	}
+}
+
+4438 = {
+	name="Gergely"
+	dynasty=101571
+	martial=8
+	diplomacy=4
+	intrigue=3
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="amateurish_plotter"
+	father=4437
+	1049.1.1 = {
+		birth="1049.1.1"
+	}
+	1065.1.2 = {
+		add_spouse=4439
+	}
+	1122.1.1 = {
+		death="1122.1.1"
+	}
+}
+
+4439 = {
+	name="Ildikó"
+	# AKA: Ildiko
+	female=yes
+	martial=7
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="flamboyant_schemer"
+	1050.1.1 = {
+		birth="1050.1.1"
+	}
+	1111.1.1 = {
+		death="1111.1.1"
+	}
+}
+
+4440 = {
+	name="Péter"
+	dynasty=101571
+	martial=6
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=4435
+	mother=4436
+	1066.1.1 = {
+		birth="1066.1.1"
+	}
+	1115.1.1 = {
+		death="1115.1.1"
+	}
+}
+
+4441 = {
+	name="Sugárka"
+	# AKA: Sugarka
+	female=yes
+	dynasty=101565
+	martial=4
+	diplomacy=3
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="arbitrary"
+	trait="temperate"
+	trait="thrifty_clerk"
+	father=20365
+	mother=4365
+	1042.1.1 = {
+		birth="1042.1.1"
+	}
+	1099.1.1 = {
+		death="1099.1.1"
+	}
+}
+
+4442 = {
+	name="Zila"
+	dynasty=101565
+	female=yes
+	martial=5
+	diplomacy=9
+	intrigue=4
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="detached_priest"
+	father=20365
+	mother=4365
+	1044.1.1 = {
+		birth="1044.1.1"
+	}
+	1106.1.1 = {
+		death="1106.1.1"
+	}
+}
+
+4443 = {
+	name="Skolasztika"
+	female=yes
+	dynasty=19001
+	martial=5
+	diplomacy=3
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="zealous"
+	trait="thrifty_clerk"
+	1031.1.1 = {
+		birth="1031.1.1"
+	}
+	1089.1.1 = {
+		death="1089.1.1"
+	}
+}
+
+4444 = {
+	name="Etel"
+	female=yes
+	dynasty=19003
+	martial=7
+	diplomacy=5
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="greedy"
+	trait="cynical"
+	trait="amateurish_plotter"
+	1031.1.1 = {
+		birth="1031.1.1"
+	}
+	1095.1.1 = {
+		death="1095.1.1"
+	}
+}
+
+460 = {
+	name="Taksony"
+	dynasty=708
+	martial=5
+	diplomacy=7
+	intrigue=7
+	stewardship=5
+	religion="tengri_pagan"
+	culture="hungarian"
+	trait="proud"
+	trait="underhanded_rogue"
+	father=159135
+	931.1.1 = {
+		birth="931.1.1"
+	}
+	947.1.1 = {
+		add_spouse=483
+	}
+	972.1.1 = {
+		death="972.1.1"
+	}
+}
+
+461711 = {
+	name="Maria"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=4
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="flamboyant_schemer"
+	father=98004
+	mother=98042
+	1257.1.2 = {
+		birth="1257.1.2"
+	}
+	1323.1.26 = {
+		death="1323.1.26"
+	}
+}
+
+462 = {
+	name="Mihály"
+	# AKA: Mihaly
+	dynasty=708
+	martial=5
+	diplomacy=4
+	intrigue=8
+	stewardship=5
+	religion="tengri_pagan"
+	culture="hungarian"
+	trait="envious"
+	trait="skilled_tactician"
+	father=460
+	mother=483
+	948.1.1 = {
+		birth="948.1.1"
+	}
+	970.1.1 = {
+		add_spouse=759
+	}
+	978.1.1 = {
+		death="978.1.1"
+	}
+}
+
+463 = {
+	name="Judit"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=6
+	intrigue=8
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="flamboyant_schemer"
+	father=464
+	mother=753
+	969.1.1 = {
+		birth="969.1.1"
+	}
+	987.1.1 = {
+		death="987.1.1"
+	}
+}
+
+464 = {
+	name="Géza"
+	# AKA: Geza
+	dynasty=708
+	martial=5
+	diplomacy=8
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="cynical"
+	trait="tough_soldier"
+	father=460
+	mother=483
+	945.1.1 = {
+		birth="945.1.1"
+	}
+	967.1.1 = {
+		add_spouse=753
+	}
+	975.1.1 = {
+	remove_spouse=753
+	}
+	985.1.1 = {
+		add_spouse=759
+	}
+	997.2.1 = {
+		death="997.2.1"
+	}
+}
+
+466 = {
+	name="Vászoly"
+	# AKA: Vaszoly
+	dynasty=708
+	martial=6
+	diplomacy=4
+	intrigue=4
+	stewardship=8
+	religion="tengri_pagan"
+	culture="hungarian"
+	trait="wroth"
+	trait="tough_soldier"
+	father=462
+	mother=759
+	976.1.1 = {
+		birth="976.1.1"
+	}
+	1037.1.1 = {
+		death="1037.1.1"
+	}
+}
+
+468 = {
+	name="András"
+	# AKA: Andras
+	dynasty=708
+	martial=7
+	diplomacy=4
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="patient"
+	trait="charismatic_negotiator"
+	father=466
+	mother=484
+	1014.1.1 = {
+		birth="1014.1.1"
+	}
+	1039.1.1 = {
+		add_spouse=637
+	}
+	1060.10.1 = {
+		death="1060.10.1"
+	}
+}
+
+469 = {
+	name="Zsófia"
+	# AKA: Zsofia
+	female=yes
+	dynasty=708
+	martial=3
+	diplomacy=6
+	intrigue=6
+	stewardship=6
+	trait="bastard"
+	religion="catholic"
+	culture="hungarian"
+	father=470
+	1062.1.1 = {
+		birth="1062.1.1"
+	}
+	1066.1.1 = {
+	employer=472
+	}
+	1116.1.1 = {
+		death="1116.1.1"
+	}
+}
+
+470 = {
+	name="Béla"
+	# AKA: Bela
+	dynasty=708
+	martial=7
+	diplomacy=5
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="diligent"
+	trait="brave"
+	trait="skilled_tactician"
+	father=466
+	mother=484
+	1016.1.1 = {
+		birth="1016.1.1"
+	}
+	1039.1.1 = {
+		add_spouse=763
+	}
+	1063.12.1 = {
+		death="1063.12.1"
+	}
+}
+
+470030 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19063
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="proud"
+	trait="tough_soldier"
+	father=470031
+	1310.1.1 = {
+		birth="1310.1.1"
+	}
+	1335.1.2 = {
+		add_spouse=470032
+	}
+	1360.1.1 = {
+		death="1360.1.1"
+	}
+}
+
+470031 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19063
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="tough_soldier"
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1315.1.1 = {
+		death="1315.1.1"
+	}
+}
+
+470032 = {
+	name="Katarina"
+	female=yes
+	martial=4
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="humble"
+	trait="naive_appeaser"
+	1315.1.1 = {
+		birth="1315.1.1"
+	}
+	1365.1.1 = {
+		death="1365.1.1"
+	}
+}
+
+470040 = {
+	name="Tamás"
+	dynasty=19043
+	martial=7
+	diplomacy=5
+	intrigue=7
+	stewardship=9
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="charitable"
+	trait="tough_soldier"
+	father=470049
+	1285.1.2 = {
+		birth="1285.1.2"
+	}
+	1317.1.2 = {
+		add_spouse=470041
+	}
+	1328.1.2 = {
+		add_spouse=470042
+	}
+	1344.1.1 = {
+		death="1344.1.1"
+	}
+}
+
+470041 = {
+	name="Erzsébet" 
+	#AKA Erzsebet Visontai
+	female=yes
+	martial=5
+	diplomacy=5
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	1299.1.2 = {
+		birth="1299.1.2"
+	}
+	1327.1.2 = {
+		death="1327.1.2"
+	}
+}
+
+470043 = {
+	name="Kónya"
+	# AKA: Konya
+	dynasty=19043
+	martial=5
+	diplomacy=4
+	intrigue=2
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="proud"
+	trait="tough_soldier"
+	father=470040
+	mother=470041
+	1318.1.2 = {
+		birth="1318.1.2"
+	}
+	1368.1.2 = {
+		death="1368.1.2"
+	}
+}
+
+470044 = {
+	name="Mihály"
+	# AKA: Mihaly
+	dynasty=19043
+	martial=5
+	diplomacy=6
+	intrigue=3
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="zealous"
+	trait="mastermind_theologian"
+	father=470040
+	mother=470041
+	1319.1.2 = {
+		birth="1319.1.2"
+	}
+	1369.1.2 = {
+		death="1369.1.2"
+	}
+}
+
+470045 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19043
+	martial=3
+	diplomacy=4
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="tough_soldier"
+	father=470040
+	mother=470041
+	1321.1.2 = {
+		birth="1321.1.2"
+	}
+	1371.1.2 = {
+		death="1371.1.2"
+	}
+}
+
+470046 = {
+	name="Gáspár"
+	# AKA: Gaspar
+	dynasty=19043
+	martial=3
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470040
+	mother=470042
+	1329.1.2 = {
+		birth="1329.1.2"
+	}
+	1379.1.2 = {
+		death="1379.1.2"
+	}
+}
+
+470047 = {
+	name="Anna"
+	female=yes
+	dynasty=19043
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=470040
+	mother=470042
+	1332.1.2 = {
+		birth="1332.1.2"
+	}
+	1382.1.2 = {
+		death="1382.1.2"
+	}
+}
+
+470048 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=19043
+	martial=5
+	diplomacy=6
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	father=470040
+	mother=470042
+	1335.1.2 = {
+		birth="1335.1.2"
+	}
+	1385.1.2 = {
+		death="1385.1.2"
+	}
+}
+
+470049 = {
+	name="Farkas"
+	dynasty=19043
+	martial=4
+	diplomacy=4
+	intrigue=7
+	stewardship=10
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="charitable"
+	trait="flamboyant_schemer"
+	1257.1.2 = {
+		birth="1257.1.2"
+	}
+	1305.1.2 = {
+		death="1305.1.2"
+	}
+}
+
+470050 = {
+	name="Péter"
+	dynasty=19043
+	martial=7
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="humble"
+	trait="tough_soldier"
+	father=470049
+	1292.1.2 = {
+		birth="1292.1.2"
+	}
+	1342.1.2 = {
+		death="1342.1.2"
+	}
+}
+
+470051 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19043
+	martial=2
+	diplomacy=5
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="proud"
+	trait="thrifty_clerk"
+	father=470050
+	1316.1.2 = {
+		birth="1316.1.2"
+	}
+	1366.1.2 = {
+		death="1366.1.2"
+	}
+}
+
+470052 = {
+	name="Tamás"
+	dynasty=19043
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="tough_soldier"
+	father=470050
+	1318.1.2 = {
+		birth="1318.1.2"
+	}
+	1368.1.2 = {
+		death="1368.1.2"
+	}
+}
+
+470053 = {
+	name="Farkas"
+	dynasty=19043
+	martial=5
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="slothful"
+	trait="tough_soldier"
+	father=470050
+	1320.1.2 = {
+		birth="1320.1.2"
+	}
+	1370.1.2 = {
+		death="1370.1.2"
+	}
+}
+
+470060 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=19056
+	martial=5
+	diplomacy=4
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="slothful"
+	trait="tough_soldier"
+	1260.1.2 = {
+		birth="1260.1.2"
+	}
+	1286.1.2 = {
+		add_spouse=470061
+	}
+	1320.1.2 = {
+		death="1320.1.2"
+	}
+}
+
+470061 = {
+	name="Margit"
+	# AKA: Margit Pelejtei
+	female=yes
+	martial=4
+	diplomacy=4
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="charitable"
+	trait="flamboyant_schemer"
+	1270.1.2 = {
+		birth="1270.1.2"
+	}
+	1333.1.2 = {
+		death="1333.1.2"
+	}
+}
+
+470062 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19056
+	martial=7
+	diplomacy=4
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="patient"
+	trait="tough_soldier"
+	father=470060
+	mother=470061
+	1308.1.2 = {
+		birth="1308.1.2"
+	}
+	1330.1.2 = {
+		add_spouse=470063
+	}
+	1358.1.2 = {
+		death="1358.1.2"
+	}
+}
+
+470063 = {
+	name="Katalin"
+	female=yes
+	martial=6
+	diplomacy=4
+	intrigue=7
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="harelip"
+	trait="thrifty_clerk"
+	1311.1.2 = {
+		birth="1311.1.2"
+	}
+	1361.1.2 = {
+		death="1361.1.2"
+	}
+}
+
+470064 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19056
+	martial=5
+	diplomacy=4
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	father=470062
+	mother=470063
+	1333.1.2 = {
+		birth="1333.1.2"
+	}
+	1383.1.2 = {
+		death="1383.1.2"
+	}
+}
+
+470065 = {
+	name="Domokos"
+	dynasty=19056
+	martial=6
+	diplomacy=7
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	father=470062
+	mother=470063
+	1336.1.2 = {
+		birth="1336.1.2"
+	}
+	1386.1.2 = {
+		death="1386.1.2"
+	}
+}
+
+470070 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19057
+	martial=7
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="just"
+	trait="tough_soldier"
+	father=470071
+	mother=470073
+	1299.1.2 = {
+		birth="1299.1.2"
+	}
+	1321.1.2 = {
+		add_spouse=470074
+	}
+	1349.1.2 = {
+		death="1349.1.2"
+	}
+}
+
+470071 = {
+	name="Miklós"
+	dynasty=19057
+	martial=7
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="just"
+	trait="tough_soldier"
+	father=93755
+	1258.1.1 = {
+		birth="1258.1.1"
+	}
+	1288.1.1 = {
+		add_spouse=470072
+	}
+	1297.1.1 = {
+		add_spouse=470073
+	}
+	1320.1.1 = {
+		death="1320.1.1"
+	}
+}
+
+470072 = {
+	name="Erzsébet" 
+	#AKA Erzsebet de Daro
+	female=yes
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="thrifty_clerk"
+	1272.1.2 = {
+		birth="1272.1.2"
+	}
+	1296.1.2 = {
+		death="1296.1.2"
+	}
+}
+
+470073 = {
+	name="Erzsébet" 
+	#AKA Erzsebet Kaplyon
+	female=yes
+	martial=7
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="arbitrary"
+	trait="charitable"
+	trait="naive_appeaser"
+	1280.1.2 = {
+		birth="1280.1.2"
+	}
+	1330.1.2 = {
+		death="1330.1.2"
+	}
+}
+
+470074 = {
+	name="Anna"
+	female=yes
+	dynasty=19051
+	martial=6
+	diplomacy=5
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="lustful"
+	trait="flamboyant_schemer"
+	1302.1.2 = {
+		birth="1302.1.2"
+	}
+	1352.1.2 = {
+		death="1352.1.2"
+	}
+}
+
+470075 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19057
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="martial_cleric"
+	father=470070
+	mother=470074
+	1323.1.2 = {
+		birth="1323.1.2"
+	}
+	1373.1.2 = {
+		death="1373.1.2"
+	}
+}
+
+470076 = {
+	name="Móricz"
+	# AKA: Moricz
+	dynasty=19057
+	martial=7
+	diplomacy=7
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="slothful"
+	trait="thrifty_clerk"
+	father=470071
+	mother=470072
+	1295.1.2 = {
+		birth="1295.1.2"
+	}
+	1326.1.2 = {
+		add_spouse=470078
+	}
+	1345.1.2 = {
+		death="1345.1.2"
+	}
+}
+
+470077 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19057
+	martial=2
+	diplomacy=2
+	intrigue=8
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="patient"
+	trait="elusive_shadow"
+	father=470071
+	mother=470073
+	1300.1.2 = {
+		birth="1300.1.2"
+	}
+	1350.1.2 = {
+		death="1350.1.2"
+	}
+}
+
+470078 = {
+	name="Skolasztika Atyinai"
+	# AKA: Skolasztika Atyinai
+	female=yes
+	martial=5
+	diplomacy=4
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="gluttonous"
+	trait="midas_touched"
+	1300.1.2 = {
+		birth="1300.1.2"
+	}
+	1350.1.2 = {
+		death="1350.1.2"
+	}
+}
+
+470079 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19057
+	martial=6
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470076
+	mother=470078
+	1332.1.2 = {
+		birth="1332.1.2"
+	}
+	1382.1.2 = {
+		death="1382.1.2"
+	}
+}
+
+470080 = {
+	name="Anna"
+	female=yes
+	dynasty=19057
+	martial=5
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	father=470076
+	mother=470078
+	1335.1.2 = {
+		birth="1335.1.2"
+	}
+	1385.1.2 = {
+		death="1385.1.2"
+	}
+}
+
+470090 = {
+	name="Osli"
+	dynasty=19058
+	martial=6
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	1180.1.1 = {
+		birth="1180.1.1"
+	}
+	1230.1.1 = {
+		death="1230.1.1"
+	}
+}
+
+470091 = {
+	name="Beled"
+	dynasty=19058
+	martial=6
+	diplomacy=5
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	father=470090
+	1210.1.2 = {
+		birth="1210.1.2"
+	}
+	1272.1.2 = {
+		death="1272.1.2"
+	}
+}
+
+470092 = {
+	name="Osli"
+	dynasty=19058
+	martial=7
+	diplomacy=7
+	intrigue=8
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	father=470090
+	1211.1.1 = {
+		birth="1211.1.1"
+	}
+	1266.1.1 = {
+		death="1266.1.1"
+	}
+}
+
+470093 = {
+	name="Támas Csornai" 
+	#AKA Tamas Csornai
+	dynasty=19058
+	martial=6
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470090
+	1213.1.2 = {
+		birth="1213.1.2"
+	}
+	1272.1.2 = {
+		death="1272.1.2"
+	}
+}
+
+470094 = {
+	name="Beled"
+	# AKA: Beled Viczay
+	dynasty=19059
+	martial=6
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="intricate_webweaver"
+	father=93651
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1291.1.1 = {
+		death="1291.1.1"
+	}
+}
+
+470095 = {
+	name="Miklós"
+	dynasty=19059
+	martial=6
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="intricate_webweaver"
+	father=470094
+	1254.1.1 = {
+		birth="1254.1.1"
+	}
+	1309.1.1 = {
+		death="1309.1.1"
+	}
+}
+
+470096 = {
+	name="Imre"
+	dynasty=19059
+	martial=7
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="flamboyant_schemer"
+	father=470094
+	1257.1.1 = {
+		birth="1257.1.1"
+	}
+	1309.1.1 = {
+		death="1309.1.1"
+	}
+}
+
+470097 = {
+	name="János"
+	dynasty=19059
+	martial=6
+	diplomacy=4
+	intrigue=2
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=470094
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1310.1.1 = {
+		death="1310.1.1"
+	}
+}
+
+470098 = {
+	name="Beled"
+	dynasty=19059
+	martial=6
+	diplomacy=6
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="stutter"
+	trait="brave"
+	trait="tough_soldier"
+	father=470094
+	1266.1.1 = {
+		birth="1266.1.1"
+	}
+	1336.1.1 = {
+		death="1336.1.1"
+	}
+}
+
+470099 = {
+	name="János"
+	dynasty=19059
+	martial=4
+	diplomacy=6
+	intrigue=7
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470095
+	1284.1.1 = {
+		birth="1284.1.1"
+	}
+	1347.1.1 = {
+		death="1347.1.1"
+	}
+}
+
+470100 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19059
+	martial=1
+	diplomacy=2
+	intrigue=7
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="harelip"
+	trait="arbitrary"
+	trait="detached_priest"
+	father=470099
+	1304.1.1 = {
+		birth="1304.1.1"
+	}
+	1347.1.1 = {
+		death="1347.1.1"
+	}
+}
+
+470101 = {
+	name="Tamás"
+	dynasty=19059
+	martial=7
+	diplomacy=7
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="gluttonous"
+	trait="tough_soldier"
+	father=470099
+	1306.1.1 = {
+		birth="1306.1.1"
+	}
+	1360.1.1 = {
+		death="1360.1.1"
+	}
+}
+
+470102 = {
+	name="Anna"
+	female=yes
+	dynasty=19059
+	martial=4
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="gluttonous"
+	trait="flamboyant_schemer"
+	father=470099
+	1315.1.1 = {
+		birth="1315.1.1"
+	}
+	1360.1.1 = {
+		death="1360.1.1"
+	}
+}
+
+470103 = {
+	name="Péter"
+	dynasty=19059
+	martial=7
+	diplomacy=6
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="craven"
+	trait="flamboyant_schemer"
+	father=470096
+	1305.1.2 = {
+		birth="1305.1.2"
+	}
+	1355.1.2 = {
+		death="1355.1.2"
+	}
+}
+
+470104 = {
+	name="Ilona"
+	female=yes
+	dynasty=19059
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="lustful"
+	trait="naive_appeaser"
+	father=470096
+	1309.1.2 = {
+		birth="1309.1.2"
+	}
+	1359.1.2 = {
+		death="1359.1.2"
+	}
+}
+
+470105 = {
+	name="Péter"
+	dynasty=19059
+	martial=7
+	diplomacy=4
+	intrigue=7
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="brave"
+	trait="misguided_warrior"
+	father=470097
+	1305.1.1 = {
+		birth="1305.1.1"
+	}
+	1355.1.1 = {
+		death="1355.1.1"
+	}
+}
+
+470106 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19059
+	martial=4
+	diplomacy=4
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="charitable"
+	trait="tough_soldier"
+	father=470098
+	1306.1.2 = {
+		birth="1306.1.2"
+	}
+	1356.1.2 = {
+		death="1356.1.2"
+	}
+}
+
+470107 = {
+	name="Osli"
+	dynasty=19059
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470106
+	1325.1.2 = {
+		birth="1325.1.2"
+	}
+	1375.1.2 = {
+		death="1375.1.2"
+	}
+}
+
+470108 = {
+	name="Osli"
+	dynasty=19058
+	martial=7
+	diplomacy=7
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470092
+	1241.1.2 = {
+		birth="1241.1.2"
+	}
+	1270.1.2 = {
+		add_spouse=470109
+	}
+	1310.1.2 = {
+		death="1310.1.2"
+	}
+}
+
+470109 = {
+	name="Erzsébet" 
+	#AKA Erzsebet Nagymartoni
+	female=yes
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="detached_priest"
+	1261.1.2 = {
+		birth="1261.1.2"
+	}
+	1332.1.2 = {
+		death="1332.1.2"
+	}
+}
+
+470110 = {
+	name="Péter"
+	dynasty=19058
+	martial=7
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="bastard"
+	trait="detached_priest"
+	father=470108
+	1288.1.2 = {
+		birth="1288.1.2"
+	}
+	1338.1.2 = {
+		death="1338.1.2"
+	}
+}
+
+470111 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19058
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="patient"
+	trait="thrifty_clerk"
+	father=470108
+	mother=470109
+	1290.1.2 = {
+		birth="1290.1.2"
+	}
+	1340.1.2 = {
+		death="1340.1.2"
+	}
+}
+
+470112 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19058
+	martial=7
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="ill"
+	trait="temperate"
+	trait="tough_soldier"
+	father=470108
+	mother=470109
+	1291.1.2 = {
+		birth="1291.1.2"
+	}
+	1330.1.2 = {
+		add_spouse=470129
+	}
+	1341.1.2 = {
+		death="1341.1.2"
+	}
+}
+
+470113 = {
+	name="Domokos"
+	dynasty=19058
+	martial=5
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="just"
+	trait="tough_soldier"
+	father=470108
+	mother=470109
+	1285.1.2 = {
+		birth="1285.1.2"
+	}
+	1335.1.2 = {
+		death="1335.1.2"
+	}
+}
+
+470114 = {
+	name="Demeter"
+	# AKA: Demeter Bresztolci
+	dynasty=19058
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="brave"
+	trait="tough_soldier"
+	father=470113
+	1320.1.2 = {
+		birth="1320.1.2"
+	}
+	1370.1.2 = {
+		death="1370.1.2"
+	}
+}
+
+470115 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19058
+	martial=5
+	diplomacy=4
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470113
+	1329.1.2 = {
+		birth="1329.1.2"
+	}
+	1379.1.2 = {
+		death="1379.1.2"
+	}
+}
+
+470116 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19058
+	martial=5
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	father=470113
+	1333.1.2 = {
+		birth="1333.1.2"
+	}
+	1383.1.2 = {
+		death="1383.1.2"
+	}
+}
+
+470117 = {
+	name="Imre"
+	dynasty=19054
+	martial=6
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="misguided_warrior"
+	father=470093
+	1238.1.2 = {
+		birth="1238.1.2"
+	}
+	1305.1.2 = {
+		death="1305.1.2"
+	}
+}
+
+470118 = {
+	name="Lõrinc"
+	# AKA: Lorinc
+	dynasty=19054
+	martial=6
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="tough_soldier"
+	father=470117
+	1270.1.2 = {
+		birth="1270.1.2"
+	}
+	1310.1.2 = {
+		add_spouse=470121
+	}
+	1330.1.10 = {
+		death="1330.1.10"
+	}
+}
+
+470119 = {
+	name="Mihály"
+	# AKA: Mihaly
+	dynasty=19054
+	martial=2
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="tough_soldier"
+	father=470117
+	1298.1.2 = {
+		birth="1298.1.2"
+	}
+	1348.1.2 = {
+		death="1348.1.2"
+	}
+}
+
+470120 = {
+	name="Imre"
+	dynasty=19054
+	martial=5
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="proud"
+	trait="tough_soldier"
+	father=470117
+	1301.1.2 = {
+		birth="1301.1.2"
+	}
+	1351.1.2 = {
+		death="1351.1.2"
+	}
+}
+
+470121 = {
+	name="Katalin"
+	# AKA: Katalin Nagyamartoni
+	female=yes
+	martial=4
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="gluttonous"
+	trait="naive_appeaser"
+	1295.1.2 = {
+		birth="1295.1.2"
+	}
+	1345.1.2 = {
+		death="1345.1.2"
+	}
+}
+
+470122 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19054
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="just"
+	trait="tough_soldier"
+	father=470118
+	mother=470121
+	1310.1.2 = {
+		birth="1310.1.2"
+	}
+	1360.1.2 = {
+		death="1360.1.2"
+	}
+}
+
+470123 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19054
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="just"
+	trait="tough_soldier"
+	father=470118
+	mother=470121
+	1312.1.2 = {
+		birth="1312.1.2"
+	}
+	1362.1.2 = {
+		death="1362.1.2"
+	}
+}
+
+470124 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19054
+	martial=2
+	diplomacy=3
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="just"
+	trait="detached_priest"
+	father=470118
+	mother=470121
+	1315.1.2 = {
+		birth="1315.1.2"
+	}
+	1365.1.2 = {
+		death="1365.1.2"
+	}
+}
+
+470125 = {
+	name="Lõrinc"
+	# AKA: Lorinc
+	dynasty=19054
+	martial=7
+	diplomacy=1
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="ill"
+	trait="tough_soldier"
+	father=470118
+	mother=470121
+	1317.1.2 = {
+		birth="1317.1.2"
+	}
+	1367.1.2 = {
+		death="1367.1.2"
+	}
+}
+
+470126 = {
+	name="Benedek"
+	dynasty=19054
+	martial=2
+	diplomacy=5
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="arbitrary"
+	trait="thrifty_clerk"
+	father=470118
+	mother=470121
+	1320.1.2 = {
+		birth="1320.1.2"
+	}
+	1370.1.2 = {
+		death="1370.1.2"
+	}
+}
+
+470127 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19054
+	martial=8
+	diplomacy=8
+	intrigue=2
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470120
+	1331.1.2 = {
+		birth="1331.1.2"
+	}
+	1381.1.2 = {
+		death="1381.1.2"
+	}
+}
+
+470128 = {
+	name="Anna"
+	female=yes
+	martial=5
+	diplomacy=7
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="gluttonous"
+	trait="flamboyant_schemer"
+	1307.1.2 = {
+		birth="1307.1.2"
+	}
+	1357.1.2 = {
+		death="1357.1.2"
+	}
+}
+
+470129 = {
+	name="Erzsébet"
+	female=yes
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="temperate"
+	trait="naive_appeaser"
+	1309.1.2 = {
+		birth="1309.1.2"
+	}
+	1359.1.2 = {
+		death="1359.1.2"
+	}
+}
+
+470130 = {
+	name="Tamás"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=2
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=93662
+	1240.1.1 = {
+		birth="1240.1.1"
+	}
+	1299.1.1 = {
+		death="1299.1.1"
+	}
+}
+
+470131 = {
+	name="Lõrinc"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470130
+	1280.1.2 = {
+		birth="1280.1.2"
+	}
+	1315.1.10 = {
+		death="1315.1.10"
+	}
+}
+
+470132 = {
+	name="Miklós"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="tough_soldier"
+	father=470130
+	1289.1.2 = {
+		birth="1289.1.2"
+	}
+	1330.1.10 = {
+		death="1330.1.10"
+	}
+}
+
+470133 = {
+	name="Csanád"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="temperate"
+	trait="mastermind_theologian"
+	father=470130
+	1293.1.2 = {
+		birth="1293.1.2"
+	}
+	1343.1.2 = {
+		death="1343.1.2"
+	}
+}
+
+470134 = {
+	name="Pongrác"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="tough_soldier"
+	father=470130
+	1295.1.2 = {
+		birth="1295.1.2"
+	}
+	1330.1.10 = {
+		death="1330.1.10"
+	}
+}
+
+470135 = {
+	name="János"
+	dynasty=19045
+	martial=7
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="slothful"
+	trait="tough_soldier"
+	father=470131
+	1305.1.2 = {
+		birth="1305.1.2"
+	}
+	1355.1.2 = {
+		death="1355.1.2"
+	}
+}
+
+470136 = {
+	name="Tamás"
+	dynasty=19045
+	martial=5
+	diplomacy=4
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="wroth"
+	trait="proud"
+	trait="charismatic_negotiator"
+	father=470131
+	1309.1.2 = {
+		birth="1309.1.2"
+	}
+	1359.1.2 = {
+		death="1359.1.2"
+	}
+}
+
+470137 = {
+	name="István"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="detached_priest"
+	father=470132
+	1315.1.2 = {
+		birth="1315.1.2"
+	}
+	1365.1.2 = {
+		death="1365.1.2"
+	}
+}
+
+470138 = {
+	name="Demeter"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="ill"
+	trait="proud"
+	trait="tough_soldier"
+	father=470132
+	1318.1.2 = {
+		birth="1318.1.2"
+	}
+	1368.1.2 = {
+		death="1368.1.2"
+	}
+}
+
+470139 = {
+	name="György"
+	dynasty=19045
+	martial=2
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="diligent"
+	trait="flamboyant_schemer"
+	father=470132
+	1320.1.2 = {
+		birth="1320.1.2"
+	}
+	1370.1.2 = {
+		death="1370.1.2"
+	}
+}
+
+470140 = {
+	name="Miklós"
+	dynasty=19045
+	martial=2
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="diligent"
+	trait="thrifty_clerk"
+	father=470132
+	1322.1.2 = {
+		birth="1322.1.2"
+	}
+	1372.1.2 = {
+		death="1372.1.2"
+	}
+}
+
+470141 = {
+	name="Tamás"
+	dynasty=19045
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="martial_cleric"
+	father=470134
+	1318.1.2 = {
+		birth="1318.1.2"
+	}
+	1368.1.2 = {
+		death="1368.1.2"
+	}
+}
+
+470142 = {
+	name="Dorottya"
+	female=yes
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="honest"
+	trait="thrifty_clerk"
+	1309.1.2 = {
+		birth="1309.1.2"
+	}
+	1359.1.2 = {
+		death="1359.1.2"
+	}
+}
+
+470150 = {
+	name="Henrik"
+	dynasty=19032
+	martial=7
+	diplomacy=6
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="tough_soldier"
+	father=93768
+	1270.1.1 = {
+		birth="1270.1.1"
+	}
+	1309.1.1 = {
+		death="1309.1.1"
+	}
+}
+
+470151 = {
+	name="Péter"
+	dynasty=19032
+	martial=5
+	diplomacy=7
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="humble"
+	trait="tough_soldier"
+	father=470150
+	1300.1.1 = {
+		birth="1300.1.1"
+	}
+	1326.1.1 = {
+		add_spouse=470152
+	}
+	1351.1.1 = {
+		death="1351.1.1"
+	}
+}
+
+470152 = {
+	name="Anna"
+	female = yes
+	dynasty=19007 #Blagai
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=2
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="envious"
+	trait="charismatic_negotiator"
+	father=32645
+	1310.1.1 = {
+		birth="1310.1.1"
+	}
+	1360.1.1 = {
+		death="1360.1.1"
+	}
+}
+
+470160 = {
+	name="István"
+	# AKA: Istvan Cseh
+	dynasty=19010
+	martial=7
+	diplomacy=7
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="brave"
+	trait="charitable"
+	trait="tough_soldier"
+	father=470161
+	mother=470162
+	1301.1.2 = {
+		birth="1301.1.2"
+	}
+	1333.1.2 = {
+		add_spouse=470164
+	}
+	1351.1.2 = {
+		death="1351.1.2"
+	}
+}
+
+470162 = {
+	name="Anna"
+	female=yes
+	dynasty=19010
+	martial=2
+	diplomacy=6
+	intrigue=2
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="thrifty_clerk"
+	father=470163
+	1275.1.2 = {
+		birth="1275.1.2"
+	}
+	1325.1.2 = {
+		death="1325.1.2"
+	}
+}
+
+470163 = {
+	name="Péter"
+	dynasty=19010
+	martial=5
+	diplomacy=4
+	intrigue=2
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="tough_soldier"
+	father=93683
+	1236.1.1 = {
+		birth="1236.1.1"
+	}
+	1278.1.1 = {
+		death="1278.1.1"
+	}
+}
+
+470164 = {
+	name="Anna"
+	female=yes
+	martial=2
+	diplomacy=2
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="greedy"
+	trait="flamboyant_schemer"
+	1309.1.2 = {
+		birth="1309.1.2"
+	}
+	1359.1.2 = {
+		death="1359.1.2"
+	}
+}
+
+470180 = {
+	name="Domokos"
+	dynasty=19060
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="envious"
+	trait="tough_soldier"
+	father=93718
+	1237.1.1 = {
+		birth="1237.1.1"
+	}
+	1280.1.1 = {
+		death="1280.1.1"
+	}
+}
+
+470181 = {
+	name="Doncs"
+	dynasty=19060
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="patient"
+	trait="lustful"
+	trait="tough_soldier"
+	father=470180
+	1275.1.1 = {
+		birth="1275.1.1"
+	}
+	1296.1.1 = {
+		add_spouse=470182
+	}
+	1345.7.22 = {
+		death="1345.7.22"
+	}
+}
+
+470182 = {
+	name="Klára"
+	# AKA: Klara
+	female=yes
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="charitable"
+	trait="flamboyant_schemer"
+	1280.1.2 = {
+		birth="1280.1.2"
+	}
+	1330.1.2 = {
+		death="1330.1.2"
+	}
+}
+
+470183 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=19060
+	martial=5
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="chaste"
+	trait="tough_soldier"
+	father=470181
+	mother=470182
+	1307.1.2 = {
+		birth="1307.1.2"
+	}
+	1357.1.2 = {
+		death="1357.1.2"
+	}
+}
+
+470184 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19060
+	martial=6
+	diplomacy=2
+	intrigue=2
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="brave"
+	trait="misguided_warrior"
+	father=470181
+	mother=470182
+	1310.1.2 = {
+		birth="1310.1.2"
+	}
+	1360.1.2 = {
+		death="1360.1.2"
+	}
+}
+
+470185 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=19060
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="chaste"
+	trait="scholarly_theologian"
+	father=470181
+	mother=470182
+	1311.1.2 = {
+		birth="1311.1.2"
+	}
+	1361.1.2 = {
+		death="1361.1.2"
+	}
+}
+
+470186 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19060
+	martial=5
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="lustful"
+	trait="tough_soldier"
+	father=470181
+	mother=470182
+	1313.1.2 = {
+		birth="1313.1.2"
+	}
+	1363.1.2 = {
+		death="1363.1.2"
+	}
+}
+
+470187 = {
+	name="Klára"
+	# AKA: Klara
+	female=yes
+	dynasty=19060
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="lustful"
+	trait="naive_appeaser"
+	father=470181
+	mother=470182
+	1311.1.2 = {
+		birth="1311.1.2"
+	}
+	1361.1.2 = {
+		death="1361.1.2"
+	}
+}
+
+470190 = {
+	name="Ábrahám"
+	# AKA: abraham
+	dynasty=19061
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="lustful"
+	trait="tough_soldier"
+	father=93635
+	1246.1.1 = {
+		birth="1246.1.1"
+	}
+	1307.1.1 = {
+		death="1307.1.1"
+	}
+}
+
+470191 = {
+	name="Péter"
+	dynasty=19061
+	martial=6
+	diplomacy=6
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="craven"
+	trait="temperate"
+	trait="elusive_shadow"
+	father=470190
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1327.1.1 = {
+		add_spouse=470194
+	}
+	1347.1.1 = {
+		death="1347.1.1"
+	}
+}
+
+470192 = {
+	name="Sebes"
+	dynasty=19061
+	martial=7
+	diplomacy=7
+	intrigue=3
+	stewardship=2
+	religion="catholic"
+	culture="hungarian"
+	trait="charitable"
+	trait="proud"
+	trait="tough_soldier"
+	father=470190
+	1290.1.1 = {
+		birth="1290.1.1"
+	}
+	1330.1.1 = {
+		add_spouse=470187
+	}
+	1348.1.1 = {
+		death="1348.1.1"
+	}
+}
+
+470193 = {
+	name="György"
+	dynasty=19061
+	martial=5
+	diplomacy=7
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	father=470192
+	mother=470187
+	1336.1.2 = {
+		birth="1336.1.2"
+	}
+	1386.1.2 = {
+		death="1386.1.2"
+	}
+}
+
+470194 = {
+	name="Pona"
+	female=yes
+	martial=4
+	diplomacy=4
+	intrigue=3
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="honest"
+	trait="naive_appeaser"
+	1306.1.2 = {
+		birth="1306.1.2"
+	}
+	1360.1.2 = {
+		death="1360.1.2"
+	}
+}
+
+470200 = {
+	name="Bereck"
+	dynasty=19062
+	martial=5
+	diplomacy=7
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="martial_cleric"
+	father=93642
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1320.1.1 = {
+		death="1320.1.1"
+	}
+}
+
+470201 = {
+	name="András"
+	# AKA: Andras
+	dynasty=19062
+	martial=2
+	diplomacy=7
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="scholarly_theologian"
+	father=470200
+	1295.1.2 = {
+		birth="1295.1.2"
+	}
+	1345.1.2 = {
+		death="1345.1.2"
+	}
+}
+
+470202 = {
+	name="János"
+	# AKA: Janos
+	dynasty=19062
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="deceitful"
+	trait="lustful"
+	trait="brave"
+	trait="tough_soldier"
+	father=470200
+	1301.1.2 = {
+		birth="1301.1.2"
+	}
+	1351.1.2 = {
+		death="1351.1.2"
+	}
+}
+
+470203 = {
+	name="Lõkös"
+	# AKA: Lokos
+	dynasty=19062
+	martial=4
+	diplomacy=8
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="charitable"
+	trait="tough_soldier"
+	father=470200
+	1303.1.2 = {
+		birth="1303.1.2"
+	}
+	1330.1.10 = {
+		death="1330.1.10"
+	}
+}
+
+470204 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19062
+	martial=4
+	diplomacy=8
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="humble"
+	trait="charitable"
+	trait="tough_soldier"
+	father=470200
+	1305.1.2 = {
+		birth="1305.1.2"
+	}
+	1355.1.2 = {
+		death="1355.1.2"
+	}
+}
+
+470205 = {
+	name="Benedek"
+	dynasty=19062
+	martial=5
+	diplomacy=6
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="charitable"
+	trait="tough_soldier"
+	father=470203
+	1322.1.2 = {
+		birth="1322.1.2"
+	}
+	1372.1.2 = {
+		death="1372.1.2"
+	}
+}
+
+470206 = {
+	name="Péter"
+	dynasty=19062
+	martial=6
+	diplomacy=4
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="tough_soldier"
+	father=470203
+	1325.1.2 = {
+		birth="1325.1.2"
+	}
+	1375.1.2 = {
+		death="1375.1.2"
+	}
+}
+
+470210 = {
+	name="Benedek"
+	dynasty=19014
+	martial=6
+	diplomacy=6
+	intrigue=6
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="brave"
+	trait="tough_soldier"
+	1279.1.2 = {
+		birth="1279.1.2"
+	}
+	1322.1.10 = {
+		death="1322.1.10"
+	}
+}
+
+470212 = {
+	name="Jakab"
+	dynasty=19014
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="brave"
+	trait="tough_soldier"
+	father=470210
+	1299.1.2 = {
+		birth="1299.1.2"
+	}
+	1349.1.2 = {
+		death="1349.1.2"
+	}
+}
+
+470213 = {
+	name="Miklós"
+	# AKA: Miklos
+	dynasty=19014
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="cynical"
+	trait="slothful"
+	trait="pneumonic"
+	trait="tough_soldier"
+	father=470210
+	1300.1.2 = {
+		birth="1300.1.2"
+	}
+	1350.1.2 = {
+		death="1350.1.2"
+	}
+}
+
+470214 = {
+	name="Rafain"
+	dynasty=19014
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="greedy"
+	trait="brave"
+	trait="tough_soldier"
+	father=470210
+	1302.1.2 = {
+		birth="1302.1.2"
+	}
+	1352.1.2 = {
+		death="1352.1.2"
+	}
+}
+
+470215 = {
+	name="András"
+	# AKA: Andras
+	dynasty=19014
+	martial=5
+	diplomacy=1
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="arbitrary"
+	trait="misguided_warrior"
+	father=470210
+	1308.1.2 = {
+		birth="1308.1.2"
+	}
+	1358.1.2 = {
+		death="1358.1.2"
+	}
+}
+
+470216 = {
+	name="Pál"
+	# AKA: Pal
+	dynasty=19014
+	martial=5
+	diplomacy=5
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="proud"
+	trait="honest"
+	trait="tough_soldier"
+	father=470210
+	1313.1.2 = {
+		birth="1313.1.2"
+	}
+	1363.1.2 = {
+		death="1363.1.2"
+	}
+}
+
+470217 = {
+	name="Dózsa"
+	# AKA: Dozsa
+	dynasty=19014
+	martial=5
+	diplomacy=5
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="slothful"
+	trait="proud"
+	trait="scholarly_theologian"
+	father=470210
+	1319.1.2 = {
+		birth="1319.1.2"
+	}
+	1369.1.2 = {
+		death="1369.1.2"
+	}
+}
+
+470218 = {
+	name="Klára"
+	# AKA: Klara
+	female=yes
+	dynasty=19014
+	martial=2
+	diplomacy=5
+	intrigue=3
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="proud"
+	trait="charitable"
+	trait="thrifty_clerk"
+	father=470210
+	1310.1.2 = {
+		birth="1310.1.2"
+	}
+	1360.1.2 = {
+		death="1360.1.2"
+	}
+}
+
+471 = {
+	name="Zsófia"
+	# AKA: Zsofia
+	female=yes
+	dynasty=708
+	martial=8
+	diplomacy=8
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="diligent"
+	father=470
+	mother=763
+	1046.1.1 = {
+		birth="1046.1.1"
+	}
+	1095.6.18 = {
+		death="1095.6.18"
+	}
+}
+
+472 = {
+	name="Géza"
+	# AKA: Geza
+	dynasty=708
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="kind"
+	trait="chaste"
+	trait="honest"
+	trait="charismatic_negotiator"
+	father=470
+	mother=763
+	1044.1.1 = {
+		birth="1044.1.1"
+	}
+	1062.1.1 = {
+		add_spouse=479
+	}
+	1077.4.25 = {
+		death="1077.4.25"
+	}
+}
+
+473 = {
+	name="Eufémia"
+	# AKA: Eufemia
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=4
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="honest"
+	trait="thrifty_clerk"
+	father=470
+	mother=763
+	1049.1.1 = {
+		birth="1049.1.1"
+	}
+	1066.1.1 = {
+	employer=472
+	}
+	1111.4.2 = {
+		death="1111.4.2"
+	}
+}
+
+474 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=708
+	martial=6
+	diplomacy=5
+	intrigue=5
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="diligent"
+	trait="just"
+	trait="proud"
+	trait="gluttonous"
+	trait="honest"
+	trait="brilliant_strategist"
+	father=470
+	mother=763
+	1047.1.1 = {
+		birth="1047.1.1"
+	}
+	1077.1.1 = {
+		add_spouse=1399
+	}
+	1095.7.29 = {
+		death="1095.7.29"
+	}
+}
+
+475 = {
+	name="Ilona"
+	female=yes
+	dynasty=708
+	martial=8
+	diplomacy=4
+	intrigue=8
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="gluttonous"
+	trait="elusive_shadow"
+	father=470
+	mother=763
+	1048.1.1 = {
+		birth="1048.1.1"
+	}
+	1091.1.1 = {
+		death="1091.1.1"
+	}
+}
+
+476 = {
+	name="Salamon"
+	dynasty=708
+	martial=6
+	diplomacy=4
+	intrigue=5
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="cynical"
+	trait="tough_soldier"
+	father=468
+	mother=637
+	1053.1.1 = {
+		birth="1053.1.1"
+	}
+	1063.1.1 = {
+		add_spouse=1476
+	}
+	1087.1.1 = {
+		death="1087.1.1"
+	}
+}
+
+477 = {
+	name="Adelaida"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=7
+	intrigue=8
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="gluttonous"
+	trait="scholarly_theologian"
+	father=468
+	mother=637
+	1040.1.1 = {
+		birth="1040.1.1"
+	}
+	1062.1.27 = {
+		death="1062.1.27"
+	}
+}
+
+478 = {
+	name="Dávid"
+	# AKA: David
+	dynasty=708
+	martial=8
+	diplomacy=5
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="arbitrary"
+	trait="tough_soldier"
+	father=468
+	mother=637
+	1054.1.1 = {
+		birth="1054.1.1"
+	}
+	1066.1.1 = {
+	employer=476
+	}
+	1094.1.1 = {
+		death="1094.1.1"
+	}
+}
+
+480 = {
+	name="Kálmán"
+	# AKA: Kalman
+	dynasty=708
+	martial=5
+	diplomacy=8
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="hunchback"
+	trait="scholarly_theologian"
+	father=472
+	mother=479
+	1065.1.1 = {
+		birth="1065.1.1"
+	}
+	1097.1.2 = {
+	capital=k_hungary
+	}
+	1097.1.2 = {
+		add_spouse=98008
+	}
+	1104.1.2 = {
+		add_spouse=98018
+	}
+	1112.1.2 = {
+	remove_spouse=98018
+	}
+	1116.2.3 = {
+		death="1116.2.3"
+	}
+}
+
+482 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=708
+	martial=6
+	diplomacy=5
+	intrigue=6
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="just"
+	trait="patient"
+	trait="diligent"
+	trait="martial_cleric"
+	father=464
+	mother=753
+	975.1.1 = {
+		birth="975.1.1"
+	}
+	996.1.1 = {
+		add_spouse=1297
+	}
+	1038.8.15 = {
+		death="1038.8.15"
+	}
+}
+
+484 = {
+	name="Tátony"
+	# AKA: Tatony
+	dynasty=180
+	female=yes
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=5
+	religion="tengri_pagan"
+	culture="hungarian"
+	trait="honest"
+	trait="fortune_builder"
+	995.1.1 = {
+		birth="995.1.1"
+	}
+	1052.1.1 = {
+		death="1052.1.1"
+	}
+}
+
+485 = {
+	name="Levente"
+	dynasty=708
+	martial=7
+	diplomacy=6
+	intrigue=3
+	stewardship=4
+	religion="tengri_pagan"
+	culture="hungarian"
+	trait="charitable"
+	trait="cynical"
+	trait="tough_soldier"
+	father=466
+	mother=484
+	1018.1.1 = {
+		birth="1018.1.1"
+	}
+	1047.1.1 = {
+		death="1047.1.1"
+	}
+}
+
+486 = {
+	name="György"
+	dynasty=708
+	martial=4
+	diplomacy=5
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="bastard"
+	trait="diligent"
+	trait="thrifty_clerk"
+	father=468
+	1037.1.1 = {
+		birth="1037.1.1"
+	}
+	1066.1.1 = {
+	employer=984
+	}
+	1090.1.1 = {
+		death="1090.1.1"
+	}
+}
+
+487 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=708
+	martial=4
+	diplomacy=5
+	intrigue=7
+	stewardship=4
+	religion="tengri_pagan"
+	culture="hungarian"
+	trait="wroth"
+	trait="misguided_warrior"
+	father=462
+	mother=759
+	975.1.1 = {
+		birth="975.1.1"
+	}
+	1029.1.1 = {
+		death="1029.1.1"
+	}
+}
+
+488 = {
+	name="Ottó"
+	# AKA: Otto
+	dynasty=708
+	martial=5
+	diplomacy=4
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=482
+	mother=1297
+	1002.1.1 = {
+		birth="1002.1.1"
+	}
+	1010.1.1 = {
+		death="1010.1.1"
+	}
+}
+
+489 = {
+	name="Imre"
+	dynasty=708
+	martial=7
+	diplomacy=8
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="honest"
+	trait="kind"
+	trait="martial_cleric"
+	father=482
+	mother=1297
+	1007.1.1 = {
+		birth="1007.1.1"
+	}
+	1031.11.2 = {
+		death="1031.11.2"
+	}
+}
+
+490 = {
+	name="Odola"
+	dynasty=708
+	female=yes
+	martial=4
+	diplomacy=4
+	intrigue=5
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="arbitrary"
+	trait="naive_appeaser"
+	father=464
+	mother=753
+	971.1.1 = {
+		birth="971.1.1"
+	}
+	1023.1.1 = {
+		death="1023.1.1"
+	}
+}
+
+491 = {
+	name="Sára"
+	# AKA: Sara
+	female=yes
+	dynasty=19053
+	martial=6
+	diplomacy=5
+	intrigue=8
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="kind"
+	trait="wroth"
+	trait="amateurish_plotter"
+	father=4427
+	1016.1.1 = {
+		birth="1016.1.1"
+	}
+	1066.1.1 = {
+	employer=20369
+	}
+	1070.1.1 = {
+		death="1070.1.1"
+	}
+}
+
+492 = {
+	name="Ilona"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=7
+	intrigue=3
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="ill"
+	trait="diligent"
+	trait="scholarly_theologian"
+	father=464
+	mother=753
+	973.1.1 = {
+		birth="973.1.1"
+	}
+	1000.1.1 = {
+		death="1000.1.1"
+	}
+}
+
+495 = {
+	name="Mária"
+	# AKA: Maria
+	female=yes
+	dynasty=708
+	martial=2
+	diplomacy=7
+	intrigue=8
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="patient"
+	trait="thrifty_clerk"
+	father=464
+	mother=759
+	989.1.1 = {
+		birth="989.1.1"
+	}
+	1026.1.1 = {
+		death="1026.1.1"
+	}
+}
+
+497 = {
+	name="Péter"
+	# AKA: Pietro Oddone
+	dynasty=101562
+	martial=4
+	diplomacy=4
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="envious"
+	trait="craven"
+	trait="underhanded_rogue"
+	father=496
+	mother=495
+	1011.1.1 = {
+		birth="1011.1.1"
+	}
+	1050.1.1= { 
+		add_spouse=30213
+	}
+	1055.1.1= { 
+	remove_spouse=30213
+	}
+	1060.8.30 = {
+		death="1060.8.30"
+	}
+}
+
+499 = {
+	name="Sarolta"
+	dynasty=708
+	female=yes
+	martial=3
+	diplomacy=4
+	intrigue=4
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="intricate_webweaver"
+	father=464
+	mother=759
+	987.1.1 = {
+		birth="987.1.1"
+	}
+	1053.1.1 = {
+		death="1053.1.1"
+	}
+}
+
+599 = {
+	name="Predslava"
+	# AKA: Predeslava
+	female=yes
+	religion="pagan"
+	culture="hungarian"
+	942.1.2 = {
+		birth="942.1.2"
+	}
+	980.1.2 = {
+		death="980.1.2"
+	}
+}
+
+98000 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=708
+	martial=4
+	diplomacy=6
+	intrigue=8
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="envious"
+	trait="impaler"
+	trait="proud"
+	trait="intricate_webweaver"
+	father=219530
+	mother=218511
+	1131.1.2 = {
+		birth="1131.1.2"
+	}
+	1136.1.2 = {
+		add_spouse=221513
+	}
+	1147.6.1 = {
+	remove_spouse=221513
+	}
+	1163.1.14 = {
+		death="1163.1.14"
+	}
+}
+
+98001 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=708
+	martial=2
+	diplomacy=4
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="slothful"
+	trait="proud"
+	trait="naive_appeaser"
+	father=219530
+	mother=218511
+	1133.1.2 = {
+		birth="1133.1.2"
+	}
+	1156.1.2 = {
+		add_spouse=223021
+	}
+	1165.4.11 = {
+		death="1165.4.11"
+	}
+}
+
+98002 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=708
+	martial=2
+	diplomacy=1
+	intrigue=4
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="ill"
+	trait="amateurish_plotter"
+	father=219501
+	mother=210503
+	1199.1.2 = {
+		birth="1199.1.2"
+	}
+	#1146.1.2 = {
+	#add_spouse=222573
+	#}
+	1205.5.7 = {
+		death="1205.5.7"
+	}
+}
+
+98003 = {
+	name="Béla"
+	dynasty=708
+	martial=6
+	diplomacy=5
+	intrigue=8
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	trait="temperate"
+	trait="brave"
+	trait="skilled_tactician"
+	father=219502
+	mother=212946
+	1206.11.29 = {
+		birth="1206.11.29"
+	}
+	1218.1.2 = {
+		add_spouse=98033
+	}
+	1270.5.3 = {
+		death="1270.5.3"
+	}
+}
+
+98004 = {
+	name="István"
+	dynasty=708
+	martial=6
+	diplomacy=5
+	intrigue=8
+	stewardship=2
+	religion="catholic"
+	culture="hungarian"
+	trait="greedy"
+	trait="envious"
+	trait="deceitful"
+	trait="tough_soldier"
+	father=98003
+	mother=98033
+	1239.11.1 = {
+		birth="1239.11.1"
+	}
+	1253.1.2 = {
+		add_spouse=98042
+	}
+	1272.8.6 = {
+		death="1272.8.6"
+	}
+}
+
+98005 = {
+	name="László"
+	# AKA: Laszlo
+	dynasty=708
+	martial=6
+	diplomacy=5
+	intrigue=5
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="lustful"
+	trait="hedonist"
+	trait="indulgent_wastrel"
+	father=98004
+	1262.8.5 = {
+	birth="1262.8.5"
+	}
+	1278.1.1 = {
+		add_spouse=32789 #Elizabeth d'Anjou
+	} 
+	1290.7.10 = {
+	death="1290.7.10"
+	}
+}
+
+98006 = {
+	name="István"
+	# AKA: Istvan
+	dynasty=708
+	martial=2
+	diplomacy=7
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="duelist"
+	trait="gregarious"
+	trait="intricate_webweaver"
+	father=219502
+	mother=98025
+	1236.1.1 = {
+		birth="1236.1.1"
+	}
+	1264.1.2 = {
+		add_spouse=182018 #Tomasini Morosini
+	}
+	1271.1.1 = {
+		death="1271.1.1"
+	}
+}
+
+98007 = {
+	name="András"
+	# AKA: Andras
+	dynasty=708
+	martial=1
+	diplomacy=6
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="slow"
+	trait="craven"
+	trait="underhanded_rogue"
+	father=98006
+	mother=182018 #Tomasini Morosini
+	1265.1.2 = {
+		birth="1265.1.2"
+	}
+	1301.1.14 = {
+		death="1301.1.14"
+	}
+}
+
+98011 = {
+	name="Erzsebet"
+	female=yes
+	dynasty=708
+	martial=1
+	diplomacy=3
+	intrigue=8
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="trusting"
+	trait="zealous"
+	trait="grey_eminence"
+	father=98003
+	mother=98033
+	1236.1.1 = {
+		birth="1236.1.1"
+	}
+	1271.10.24 = {
+		death="1271.10.24"
+	}
+}
+
+98012 = {
+	name="Anna"
+	female=yes
+	dynasty=708
+	martial=2
+	diplomacy=5
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="content"
+	trait="gregarious"
+	trait="underhanded_rogue"
+	father=98003
+	mother=98033
+	1227.1.1 = {
+		birth="1227.1.1"
+	}
+	1270.1.2 = {
+		death="1270.1.2"
+	}
+}
+
+98017 = {
+	name="Adelhaid"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=5
+	intrigue=8
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	father=470
+	mother=763
+	1050.1.1 = {
+		birth="1050.1.1"
+	}
+	1104.1.2 = {
+		death="1104.1.2"
+	}
+}
+
+98019 = {
+	name="Hedwig"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=8
+	intrigue=6
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	father=219531
+	mother=219532
+	1111.1.2 = {
+		birth="1111.1.2"
+	}
+	1140.1.2 = {
+		death="1140.1.2"
+	}
+}
+
+98020 = {
+	name="Maria"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=4
+	intrigue=6
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	father=98000
+	mother=221513
+	1147.1.2 = {
+		birth="1147.1.2"
+	}
+	1183.1.2 = {
+		death="1183.1.2"
+	}
+}
+
+98021 = {
+	name="Odola"
+	female=yes
+	dynasty=708
+	martial=7
+	diplomacy=8
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	father=219510
+	mother=222573
+	1156.1.2 = {
+		birth="1156.1.2"
+	}
+	1199.1.2 = {
+		death="1199.1.2"
+	}
+}
+
+98023 = {
+	name="Béla"
+	# AKA: Bela
+	dynasty=708
+	martial=1
+	diplomacy=2
+	intrigue=5
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	father=219511
+	mother=212542
+	1167.1.2 = {
+		birth="1167.1.2"
+	}
+	1167.3.5 = {
+		death="1167.3.5"
+	}
+}
+
+98026 = {
+	name="Anna Maria"
+	# AKA: Maria
+	female=yes
+	dynasty=708
+	martial=2
+	diplomacy=8
+	intrigue=4
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	father=219502
+	mother=212946
+	1204.1.1 = {
+		birth="1204.1.1"
+	}
+	1238.1.1 = {
+		death="1238.1.1"
+	}
+}
+
+98027 = {
+	name="Erzsébet"
+	female=yes
+	dynasty=708
+	martial=6
+	diplomacy=8
+	intrigue=2
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	father=219502
+	mother=212946
+	1207.7.7 = {
+		birth="1207.7.7"
+	}
+	1231.11.17 = {
+		death="1231.11.17"
+	}
+}
+
+98028 = {
+	name="Kálmán"
+	# AKA: Kalman
+	dynasty=708
+	martial=8
+	diplomacy=5
+	intrigue=3
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	father=219502
+	mother=212946
+	1208.1.1 = {
+		birth="1208.1.1"
+	}
+    1241.1.1 = {
+		add_spouse=125981
+    }
+	1241.4.11 = {
+		death="1241.4.11"
+	}
+}
+
+98029 = {
+	name="András"
+	# AKA: Andras
+	dynasty=708
+	martial=8
+	diplomacy=5
+	intrigue=3
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	father=219502
+	mother=212946
+	1211.1.2 = {
+		birth="1211.1.2"
+	}
+	1227.1.2 = {
+		add_spouse=125148
+	}
+	1234.1.1 = {
+		death="1234.1.1"
+	}
+}
+
+98030 = {
+	name="Yolande"
+	# AKA: Jolan
+	female=yes
+	dynasty=708
+	martial=7
+	diplomacy=4
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	father=219502
+	mother=98024
+	1215.11.2 = {
+		birth="1215.11.2"
+	}
+	1251.10.9 = {
+		death="1251.10.9"
+	}
+}
+
+98049 = {
+	name="Katalin"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=8
+	intrigue=2
+	stewardship=6
+	religion="catholic"
+	culture="hungarian"
+	father=474
+	mother=1399
+	1072.1.2 = {
+		birth="1072.1.2"
+	}
+	1107.1.2 = {
+		death="1107.1.2"
+	}
+}
+
+98031 = {
+	name="Geza"
+	dynasty=708
+	martial=5
+	diplomacy=6
+	intrigue=4
+	stewardship=8
+	religion="catholic"
+	culture="hungarian"
+	trait="charismatic_negotiator"
+	father=219517
+	1190.1.2 = {
+		birth="1190.1.2"
+	}
+	1212.1.2 = {
+		death="1212.1.2"
+	}
+}
+
+98032 = {
+	name="István"
+	dynasty=708
+	martial=3
+	diplomacy=7
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	trait="thrifty_clerk"
+	father=219517
+	1192.1.2 = {
+		birth="1192.1.2"
+	}
+	1215.1.2 = {
+		death="1215.1.2"
+	}
+}
+
+98034 = {
+	name="Kunigunda"
+	female=yes
+	dynasty=708
+	martial=2
+	diplomacy=5
+	intrigue=8
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="zealous"
+	trait="mastermind_theologian"
+	father=98003
+	mother=98033
+	1224.1.1 = {
+		birth="1224.1.1"
+	}
+	1292.7.24 = {
+		death="1292.7.24"
+	}
+}
+
+98035 = {
+	name="Margit"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=6
+	intrigue=2
+	stewardship=7
+	religion="catholic"
+	culture="hungarian"
+	trait="fortune_builder"
+	father=98003
+	mother=98033
+	1221.1.1 = {
+		birth="1221.1.1"
+	}
+	1242.4.20 = {
+		death="1242.4.20"
+	}
+}
+
+98036 = {
+	name="Katalin"
+	female=yes
+	dynasty=708
+	martial=3
+	diplomacy=4
+	intrigue=5
+	stewardship=3
+	religion="catholic"
+	culture="hungarian"
+	trait="fortune_builder"
+	father=98003
+	mother=98033
+	1229.1.1 = {
+		birth="1229.1.1"
+	}
+	1242.1.2 = {
+		death="1242.1.2"
+	}
+}
+
+98037 = {
+	name="Konstancia"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=8
+	intrigue=2
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="fortune_builder"
+	father=98003
+	mother=98033
+	1237.1.1 = {
+		birth="1237.1.1"
+	}
+	1298.1.2 = {
+		death="1298.1.2"
+	}
+}
+
+98038 = {
+	name="Jolan"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=5
+	intrigue=6
+	stewardship=1
+	religion="catholic"
+	culture="hungarian"
+	father=98003
+	mother=98033
+	1244.1.1 = {
+		birth="1244.1.1"
+	}
+	1298.3.6 = {
+		death="1298.3.6"
+	}
+}
+
+98039 = {
+	name="Margit"
+	female=yes
+	dynasty=708
+	martial=4
+	diplomacy=5
+	intrigue=6
+	stewardship=1
+	religion="catholic"
+	culture="hungarian"
+	trait="mastermind_theologian"
+	father=98003
+	mother=98033
+	1242.5.1 = {
+		birth="1242.5.1"
+	}
+	1270.1.18 = {
+		death="1270.1.18"
+	}
+}
+
+98040 = {
+	name="Béla"
+	dynasty=708
+	martial=5
+	diplomacy=7
+	intrigue=6
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	trait="mastermind_theologian"
+	father=98003
+	mother=98033
+	1243.1.1 = {
+		birth="1243.1.1"
+	}
+	1264.10.25 = {
+		add_spouse=98041
+	}
+	1269.1.1 = {
+		death="1269.1.1"
+	}
+}
+
+98043 = {
+	name="Katalin"
+	female=yes
+	dynasty=708
+	martial=5
+	diplomacy=3
+	intrigue=6
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	father=98004
+	mother=98042
+	1256.1.2 = {
+		birth="1256.1.2"
+	}
+	1314.1.2 = {
+		death="1314.1.2"
+	}
+}
+
+98044 = {
+	name="Erzsébet"
+	female=yes
+	dynasty=708
+	martial=6
+	diplomacy=8
+	intrigue=4
+	stewardship=5
+	religion="catholic"
+	culture="hungarian"
+	father=98004
+	mother=98042
+	1255.1.2 = {
+		birth="1255.1.2"
+	}
+	1326.1.2 = {
+		death="1326.1.2"
+	}
+}
+
+98045 = {
+	name="Agnes"
+	female=yes
+	dynasty=708
+	martial=6
+	diplomacy=4
+	intrigue=7
+	stewardship=2
+	religion="catholic"
+	culture="hungarian"
+	father=98004
+	mother=98042
+	1260.1.2 = {
+		birth="1260.1.2"
+	}
+	1281.1.2 = {
+		death="1281.1.2"
+	}
+}
+
+98046 = {
+	name="András"
+	dynasty=708
+	martial=7
+	diplomacy=2
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	father=98004
+	mother=98042
+	1268.1.2 = {
+		birth="1268.1.2"
+	}
+	1278.1.2 = {
+		death="1278.1.2"
+	}
+}
+
+98047 = {
+	name="Anna"
+	female=yes
+	dynasty=708
+	martial=7
+	diplomacy=2
+	intrigue=5
+	stewardship=4
+	religion="catholic"
+	culture="hungarian"
+	father=98004
+	mother=98042
+	1258.1.1 = {
+		birth="1258.1.1"
+	}
+	1285.1.1 = {
+		death="1285.1.1"
+	}
+}
+
+32637 = {
+	name="Babonjeg" 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1255.1.1 = {
+		death="1255.1.1"
+	}
+}
+
+32638 = {
+	name="Babonjeg" 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32637
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1280.1.1 = {
+		death="1280.1.1"
+	}
+}
+
+32639 = {
+	name="István" #ban of Slavonia 1310-1316
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32638
+	1255.1.1 = {
+		birth="1255.1.1"
+	}
+	1316.1.1 = {
+		death="1316.1.1"
+	}
+}
+
+32640 = {
+	name="István" 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32637
+	1232.1.1 = {
+		birth="1232.1.1"
+	}
+	1282.1.1 = {
+		death="1282.1.1"
+	}
+}
+
+32641 = {
+	name="István" #Ban of Slavonia 1278-1300
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32640
+	1255.1.1 = {
+		birth="1255.1.1"
+	}
+	1300.1.1 = {
+		death="1300.1.1"
+	}
+}
+
+32642 = {
+	name="Radoszló" 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32640
+	1256.1.1 = {
+		birth="1256.1.1"
+	}
+	1299.1.1 = {
+		death="1299.1.1"
+	}
+}
+
+32643 = {
+	name="István" 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32641
+	1290.1.1 = {
+		birth="1290.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+32644 = {
+	name="László" 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32641
+	1288.1.1 = {
+		birth="1288.1.1"
+	}
+	1338.1.1 = {
+		death="1338.1.1"
+	}
+}
+
+32645 = {
+	name="János" #ban of Slavonia 
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32638
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1334.1.1 = {
+		death="1334.1.1"
+	}
+}
+
+32646 = {
+	name="Ottó"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32638
+	1262.1.1 = {
+		birth="1262.1.1"
+	}
+	1300.1.1 = {
+		death="1300.1.1"
+	}
+}
+
+32647 = {
+	name="Radoszló"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32638
+	1264.1.1 = {
+		birth="1264.1.1"
+	}
+	1314.1.1 = {
+		death="1314.1.1"
+	}
+}
+
+32648 = {
+	name="Miklós"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32647
+	1286.1.1 = {
+		birth="1286.1.1"
+	}
+	1330.1.1 = {
+		death="1330.1.1"
+	}
+}
+
+32649 = {
+	name="Duim"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32647
+	1292.1.1 = {
+		birth="1292.1.1"
+	}
+	1369.1.1 = {
+		death="1369.1.1"
+	}
+}
+
+32650 = {
+	name="György"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32639
+	1295.1.1 = {
+		birth="1295.1.1"
+	}
+	1336.1.1 = {
+		death="1336.1.1"
+	}
+}
+
+32651 = {
+	name="János"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32639
+	1297.1.1 = {
+		birth="1297.1.1"
+	}
+	1328.1.1 = {
+		death="1328.1.1"
+	}
+}
+
+32652 = {
+	name="Dénes"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32639
+	1300.1.1 = {
+		birth="1300.1.1"
+	}
+	1370.1.1 = {
+		death="1370.1.1"
+	}
+}
+
+32653 = {
+	name="Pál"
+	dynasty=19007
+	religion="catholic"
+	culture="hungarian"
+	father=32639
+	1305.1.1 = {
+		birth="1305.1.1"
+	}
+	1380.1.1 = {
+		death="1380.1.1"
+	}
+}
+
+32654 = {
+	name="Katalin"
+	female=yes
+	dynasty=19007 #Blagai
+	religion="catholic"
+	culture="hungarian"
+	father=32639
+	1305.1.1 = {
+		birth="1305.1.1"
+	}
+	1380.1.1 = {
+		death="1380.1.1"
+	}
+}
+
+93551 = {
+	name="Hont"
+	dynasty=19053
+	religion="catholic"
+	culture="hungarian"
+	father=20369
+	1095.1.1={
+		birth="1095.1.1"
+	}
+	1155.1.1={
+		death="1155.1.1"
+	}
+}
+
+93552 = {
+	name="Martin"
+	dynasty=19053
+	religion="catholic"
+	culture="hungarian"
+	father=93551
+	1145.1.1={
+		birth="1145.1.1"
+	}
+	1203.1.1={
+		death="1203.1.1"
+	}
+}
+
+93624 = {
+	name="Márton"
+	#placeholder
+	dynasty=101570
+	religion="catholic"
+	culture="hungarian"
+	father=4412
+	1060.1.1={
+		birth="1060.1.1"
+	}
+	1110.1.1={
+		death="1110.1.1"
+	}
+}
+
+93625 = {
+	name="Márton"
+	#placeholder
+	dynasty=101570
+	religion="catholic"
+	culture="hungarian"
+	father=93624
+	1085.1.1={
+		birth="1085.1.1"
+	}
+	1135.1.1={
+		death="1135.1.1"
+	}
+}
+
+93626 = {
+	name="Miska"
+	#placeholder
+	dynasty=101570
+	religion="catholic"
+	culture="hungarian"
+	father=93625
+	1110.1.1={
+		birth="1110.1.1"
+	}
+	1160.1.1={
+		death="1160.1.1"
+	}
+}
+
+93627 = {
+	name="Kupán"
+	#placeholder
+	dynasty=101570
+	religion="catholic"
+	culture="hungarian"
+	father=93626
+	1130.1.1={
+		birth="1130.1.1"
+	}
+	1170.1.1={
+		death="1170.1.1"
+	}
+}
+
+93628 = {
+	name="Ottó"
+	#placeholder
+	dynasty=101568
+	religion="catholic"
+	culture="hungarian"
+	father=4397
+	1080.1.1={
+		birth="1080.1.1"
+	}
+	1140.1.1={
+		death="1140.1.1"
+	}
+}
+
+
+93629 = {
+	name="Tamás"
+	#placeholder
+	dynasty=101568
+	religion="catholic"
+	culture="hungarian"
+	father=93628
+	1110.1.1={
+		birth="1110.1.1"
+	}
+	1170.1.1={
+		death="1170.1.1"
+	}
+}
+
+93630 = {
+	name="Ipoly"
+	#placeholder
+	dynasty=101568
+	religion="catholic"
+	culture="hungarian"
+	father=93629
+	1150.1.1={
+		birth="1150.1.1"
+	}
+	1210.1.1={
+		death="1210.1.1"
+	}
+}
+
+93631 = {
+	name="Imre"
+	#placeholder
+	dynasty=101568
+	religion="catholic"
+	culture="hungarian"
+	father=93630
+	1190.1.1={
+		birth="1190.1.1"
+	}
+	1250.1.1={
+		death="1250.1.1"
+	}
+}
+
+93632 = {
+	name="Miklós"
+	#placeholder
+	dynasty=101568
+	religion="catholic"
+	culture="hungarian"
+	father=93631
+	1230.1.1={
+		birth="1230.1.1"
+	}
+	1290.1.1={
+		death="1290.1.1"
+	}
+}
+
+93633 = {
+	name="Bény"
+	#placeholder
+	dynasty=101568
+	religion="catholic"
+	culture="hungarian"
+	father=93632
+	1270.1.1={
+		birth="1270.1.1"
+	}
+	1320.1.1={
+		death="1320.1.1"
+	}
+}
+
+93634 = {
+	name="Sebes"
+	dynasty=19061
+	religion="catholic"
+	culture="hungarian"
+	1180.1.1 = {
+		birth="1180.1.1"
+	}
+	1239.1.1 = {
+		death="1239.1.1"
+	}
+}
+
+93635 = {
+	name="Ábrahám"
+	dynasty=19061
+	religion="catholic"
+	culture="hungarian"
+	father=93634
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1255.1.1 = {
+		death="1255.1.1"
+	}
+}
+
+93636 = {
+	name="Tamás"
+	dynasty=19061
+	religion="catholic"
+	culture="hungarian"
+	father=93635
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1287.1.1 = {
+		death="1287.1.1"
+	}
+}
+
+93637 = {
+	name="Tamás"
+	dynasty=19061
+	religion="catholic"
+	culture="hungarian"
+	father=470190
+	1270.1.1 = {
+		birth="1270.1.1"
+	}
+	1316.1.1 = {
+		death="1316.1.1"
+	}
+}
+
+93638 = {
+	name="Imre"
+	# Placeholder
+	dynasty=100537
+	religion="catholic"
+	culture="hungarian"
+	1112.1.1 = {
+		birth="1112.1.1"
+	}
+	1170.1.1 = {
+		death="1170.1.1"
+	}
+}
+
+93639 = {
+	name="Miklós"
+	dynasty=19062
+	religion="catholic"
+	culture="hungarian"
+	1206.1.1 = {
+		birth="1206.1.1"
+	}
+	1260.1.1 = {
+		death="1260.1.1"
+	}
+}
+
+93640 = {
+	name="Miklós"
+	dynasty=19062
+	religion="catholic"
+	culture="hungarian"
+	father=93639
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1291.1.1 = {
+		death="1291.1.1"
+	}
+}
+
+93641 = {
+	name="István"
+	dynasty=19062
+	religion="catholic"
+	culture="hungarian"
+	father=93639
+	1235.1.1 = {
+		birth="1235.1.1"
+	}
+	1310.1.1 = {
+		death="1310.1.1"
+	}
+}
+
+93642 = {
+	name="András"
+	dynasty=19062
+	religion="catholic"
+	culture="hungarian"
+	father=93639
+	1240.1.1 = {
+		birth="1240.1.1"
+	}
+	1290.1.1 = {
+		death="1290.1.1"
+	}
+}
+
+93643 = {
+	name="György"
+	dynasty=19062
+	religion="catholic"
+	culture="hungarian"
+	father=93642
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1307.1.1 = {
+		death="1307.1.1"
+	}
+}
+
+93644 = {
+	name="Benedek"
+	dynasty=19062
+	religion="catholic"
+	culture="hungarian"
+	father=93642
+	1265.1.1 = {
+		birth="1265.1.1"
+	}
+	1321.1.1 = {
+		death="1321.1.1"
+	}
+}
+
+93645 = {
+	name="Benedek"
+	# placeholder
+	dynasty=101563
+	religion="catholic"
+	culture="hungarian"
+	father=4358
+	1070.1.1 = {
+		birth="1070.1.1"
+	}
+	1130.1.1 = {
+		death="1130.1.1"
+	}
+}
+
+93646 = {
+	name="György"
+	# placeholder
+	dynasty=101563
+	religion="catholic"
+	culture="hungarian"
+	father=93645
+	1110.1.1 = {
+		birth="1110.1.1"
+	}
+	1170.1.1 = {
+		death="1170.1.1"
+	}
+}
+
+93647 = {
+	name="Belenik"
+	# placeholder
+	dynasty=101563
+	religion="catholic"
+	culture="hungarian"
+	father=93646
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1210.1.1 = {
+		death="1210.1.1"
+	}
+}
+
+93648 = {
+	name="Imre"
+	# placeholder
+	dynasty=101563
+	religion="catholic"
+	culture="hungarian"
+	father=93647
+	1190.1.1 = {
+		birth="1190.1.1"
+	}
+	1250.1.1 = {
+		death="1250.1.1"
+	}
+}
+
+93649 = {
+	name="Lampert"
+	# placeholder
+	dynasty=101563
+	religion="catholic"
+	culture="hungarian"
+	father=93647
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1250.1.1 = {
+		death="1250.1.1"
+	}
+}
+
+93650 = {
+	name="János"
+	dynasty=19059
+	religion="catholic"
+	culture="hungarian"
+	father=470101
+	1326.1.1 = {
+		birth="1326.1.1"
+	}
+	1394.1.1 = {
+		death="1394.1.1"
+	}
+}
+
+93651 = {
+	name="Beled"
+	dynasty=19058
+	religion="catholic"
+	culture="hungarian"
+	father=470090
+	1210.1.1 = {
+		birth="1210.1.1"
+	}
+	1236.1.1 = {
+		death="1236.1.1"
+	}
+}
+
+93652 = {
+	name="Kálmán"
+	# placeholder
+	dynasty=100450
+	religion="catholic"
+	culture="hungarian"
+	1077.1.1 = {
+		birth="1077.1.1"
+	}
+	1130.1.1 = {
+		death="1130.1.1"
+	}
+}
+
+93653 = {
+	name="Dávid"
+	# placeholder
+	dynasty=100450
+	religion="catholic"
+	culture="hungarian"
+	father=93652
+	1110.1.1 = {
+		birth="1110.1.1"
+	}
+	1160.1.1 = {
+		death="1160.1.1"
+	}
+}
+
+93654 = {
+	name="László"
+	# placeholder
+	dynasty=100450
+	religion="catholic"
+	culture="hungarian"
+	father=93653
+	1130.1.1 = {
+		birth="1130.1.1"
+	}
+	1180.1.1 = {
+		death="1180.1.1"
+	}
+}
+
+93655 = {
+	name="Elek" #real name unknown
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=4386
+	1070.1.1 = {
+		birth="1070.1.1"
+	}
+	1130.1.1 = {
+		death="1130.1.1"
+	}
+}
+
+93656 = {
+	name="Imre" #real name unknown
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93655
+	1100.1.1 = {
+		birth="1100.1.1"
+	}
+	1160.1.1 = {
+		death="1160.1.1"
+	}
+}
+
+93657 = {
+	name="Fülöp" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93656
+	1130.1.1 = {
+		birth="1130.1.1"
+	}
+	1190.1.1 = {
+		death="1190.1.1"
+	}
+}
+
+93658 = {
+	name="Benedek" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93656
+	1135.1.1 = {
+		birth="1135.1.1"
+	}
+	1195.1.1 = {
+		death="1195.1.1"
+	}
+}
+
+93659 = {
+	name="Bogyoszló" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93656
+	1140.1.1 = {
+		birth="1140.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+93660 = {
+	name="Kelemen" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93658
+	1160.1.1 = {
+		birth="1160.1.1"
+	}
+	1218.1.1 = {
+		death="1218.1.1"
+	}
+}
+
+93661 = {
+	name="Waffa" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93658
+	1163.1.1 = {
+		birth="1163.1.1"
+	}
+	1238.1.1 = {
+		death="1238.1.1"
+	}
+}
+
+93662 = {
+	name="Pongrácz"
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93660
+	1185.1.1 = {
+		birth="1185.1.1"
+	}
+	1256.1.1 = {
+		death="1256.1.1"
+	}
+}
+
+93663 = {
+	name="Izsák"
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93660
+	1187.1.1 = {
+		birth="1187.1.1"
+	}
+	1256.1.1 = {
+		death="1256.1.1"
+	}
+}
+
+93664 = {
+	name="Elek"
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93660
+	1189.1.1 = {
+		birth="1189.1.1"
+	}
+	1256.1.1 = {
+		death="1256.1.1"
+	}
+}
+
+93665 = {
+	name="Csömör"
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93660
+	1191.1.1 = {
+		birth="1191.1.1"
+	}
+	1256.1.1 = {
+		death="1256.1.1"
+	}
+}
+
+93666 = {
+	name="László"
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93662
+	1235.1.1 = {
+		birth="1235.1.1"
+	}
+	1282.1.1 = {
+		death="1282.1.1"
+	}
+}
+
+93667 = {
+	name="Makó"
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93663
+	1217.1.1 = {
+		birth="1217.1.1"
+	}
+	1285.1.1 = {
+		death="1285.1.1"
+	}
+}
+
+93668 = {
+	name="Csanád" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93661
+	1193.1.1 = {
+		birth="1193.1.1"
+	}
+	1256.1.1 = {
+		death="1256.1.1"
+	}
+}
+
+93669 = {
+	name="Dénes" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93668
+	1223.1.1 = {
+		birth="1223.1.1"
+	}
+	1290.1.1 = {
+		death="1290.1.1"
+	}
+}
+
+93670 = {
+	name="Gergely" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93668
+	1228.1.1 = {
+		birth="1228.1.1"
+	}
+	1299.1.1 = {
+		death="1299.1.1"
+	}
+}
+
+93671 = {
+	name="István" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93669
+	1253.1.1 = {
+		birth="1253.1.1"
+	}
+	1299.1.1 = {
+		death="1299.1.1"
+	}
+}
+
+93672 = {
+	name="Pál" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93669
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1332.1.1 = {
+		death="1332.1.1"
+	}
+}
+
+93673 = {
+	name="Dénes" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93669
+	1265.1.1 = {
+		birth="1265.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+93674 = {
+	name="Pál" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93671
+	1290.1.1 = {
+		birth="1290.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+93675 = {
+	name="Péter" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93671
+	1292.1.1 = {
+		birth="1292.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+93676 = {
+	name="Dénes" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93674
+	1323.1.1 = {
+		birth="1323.1.1"
+	}
+	1373.1.1 = {
+		death="1373.1.1"
+	}
+}
+
+93677 = {
+	name="Pál" 
+	dynasty=101566
+	religion="catholic"
+	culture="hungarian"
+	father=93674
+	1325.1.1 = {
+		birth="1325.1.1"
+	}
+	1375.1.1 = {
+		death="1375.1.1"
+	}
+}
+
+93678 = {
+	name="Szabolcs" #real name unknown
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	mother=4436
+	1090.1.1 = {
+		birth="1090.1.1"
+	}
+	1150.1.1 = {
+		death="1150.1.1"
+	}
+}
+
+93679 = {
+	name="István" #real name unknown
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93678
+	1130.1.1 = {
+		birth="1130.1.1"
+	}
+	1180.1.1 = {
+		death="1180.1.1"
+	}
+}
+
+93680 = {
+	name="Máté" #real name unknown
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93679
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1200.1.1 = {
+		death="1200.1.1"
+	}
+}
+
+93681 = {
+	name="Ugrin" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93680
+	1170.1.1 = {
+		birth="1170.1.1"
+	}
+	1204.1.1 = {
+		death="1204.1.1"
+	}
+}
+
+93682 = {
+	name="Miklós" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93680
+	1180.1.1 = {
+		birth="1180.1.1"
+	}
+	1239.1.1 = {
+		death="1239.1.1"
+	}
+}
+
+93683 = {
+	name="Máté" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93680
+	1185.1.1 = {
+		birth="1185.1.1"
+	}
+	1249.1.1 = {
+		death="1249.1.1"
+	}
+}
+
+93684 = {
+	name="Izsák" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93682
+	1196.1.1 = {
+		birth="1196.1.1"
+	}
+	1240.1.1 = {
+		death="1240.1.1"
+	}
+}
+
+93685 = {
+	name="Lörinc" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93682
+	1210.1.1 = {
+		birth="1210.1.1"
+	}
+	1278.1.1 = {
+		death="1278.1.1"
+	}
+}
+
+93686 = {
+	name="Lörinc" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93685
+	1240.1.1 = {
+		birth="1240.1.1"
+	}
+	1290.1.1 = {
+		death="1290.1.1"
+	}
+}
+
+93687 = {
+	name="János" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93686
+	1270.1.1 = {
+		birth="1270.1.1"
+	}
+	1358.1.1 = {
+		death="1358.1.1"
+	}
+}
+
+93688 = {
+	name="János" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93682
+	1215.1.1 = {
+		birth="1215.1.1"
+	}
+	1278.1.1 = {
+		death="1278.1.1"
+	}
+}
+
+93689 = {
+	name="Domokos" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93688
+	1245.1.1 = {
+		birth="1245.1.1"
+	}
+	1305.1.1 = {
+		death="1305.1.1"
+	}
+}
+
+93690 = {
+	name="Ugrin" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93688
+	1247.1.1 = {
+		birth="1247.1.1"
+	}
+	1305.1.1 = {
+		death="1305.1.1"
+	}
+}
+
+93691 = {
+	name="János" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93688
+	1250.1.1 = {
+		birth="1250.1.1"
+	}
+	1305.1.1 = {
+		death="1305.1.1"
+	}
+}
+
+93692 = {
+	name="Egyed" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93689
+	1265.1.1 = {
+		birth="1265.1.1"
+	}
+	1317.1.1 = {
+		death="1317.1.1"
+	}
+}
+
+93693 = {
+	name="János" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93689
+	1270.1.1 = {
+		birth="1270.1.1"
+	}
+	1317.1.1 = {
+		death="1317.1.1"
+	}
+}
+
+93694 = {
+	name="Pál" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93690
+	1277.1.1 = {
+		birth="1277.1.1"
+	}
+	1358.1.1 = {
+		death="1358.1.1"
+	}
+}
+
+93695 = {
+	name="István" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93694
+	1300.1.1 = {
+		birth="1300.1.1"
+	}
+	1363.1.1 = {
+		death="1363.1.1"
+	}
+}
+
+93696 = {
+	name="Miklós" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93694
+	1302.1.1 = {
+		birth="1302.1.1"
+	}
+	1363.1.1 = {
+		death="1363.1.1"
+	}
+}
+
+93697 = {
+	name="János" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93694
+	1304.1.1 = {
+		birth="1304.1.1"
+	}
+	1363.1.1 = {
+		death="1363.1.1"
+	}
+}
+
+93698 = {
+	name="Péter" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93697
+	1334.1.1 = {
+		birth="1334.1.1"
+	}
+	1405.1.1 = {
+		death="1405.1.1"
+	}
+}
+
+93699 = {
+	name="Márk" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93683
+	1205.1.1 = {
+		birth="1205.1.1"
+	}
+	1259.1.1 = {
+		death="1259.1.1"
+	}
+}
+
+93700 = {
+	name="István" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93683
+	1210.1.1 = {
+		birth="1210.1.1"
+	}
+	1288.1.1 = {
+		death="1288.1.1"
+	}
+}
+
+93701 = {
+	name="Máté" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93683
+	1215.1.1 = {
+		birth="1215.1.1"
+	}
+	1284.1.1 = {
+		death="1284.1.1"
+	}
+}
+
+93702 = {
+	name="István" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93699
+	1235.1.1 = {
+		birth="1235.1.1"
+	}
+	1307.1.1 = {
+		death="1307.1.1"
+	}
+}
+
+93703 = {
+	name="Péter" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93699
+	1240.1.1 = {
+		birth="1240.1.1"
+	}
+	1290.1.1 = {
+		death="1290.1.1"
+	}
+}
+
+93704 = {
+	name="Péter" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93702
+	1265.1.1 = {
+		birth="1265.1.1"
+	}
+	1337.1.1 = {
+		death="1337.1.1"
+	}
+}
+
+93705 = {
+	name="Márk" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93702
+	1267.1.1 = {
+		birth="1267.1.1"
+	}
+	1309.1.1 = {
+		death="1309.1.1"
+	}
+}
+
+93706 = {
+	name="István" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93702
+	1269.1.1 = {
+		birth="1269.1.1"
+	}
+	1329.1.1 = {
+		death="1329.1.1"
+	}
+}
+
+93707 = {
+	name="Domokos" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93704
+	1295.1.1 = {
+		birth="1295.1.1"
+	}
+	1359.1.1 = {
+		death="1359.1.1"
+	}
+}
+
+93708 = {
+	name="László" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93704
+	1297.1.1 = {
+		birth="1297.1.1"
+	}
+	1332.1.1 = {
+		death="1332.1.1"
+	}
+}
+
+93709 = {
+	name="Péter" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93704
+	1299.1.1 = {
+		birth="1299.1.1"
+	}
+	1332.1.1 = {
+		death="1332.1.1"
+	}
+}
+
+93710 = {
+	name="László" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93707
+	1325.1.1 = {
+		birth="1325.1.1"
+	}
+	1398.1.1 = {
+		death="1398.1.1"
+	}
+}
+
+93711 = {
+	name="Máté" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=470163
+	1252.1.1 = {
+		birth="1252.1.1"
+	}
+	1321.3.18 = {
+		death="1321.3.18"
+	}
+}
+
+93712 = {
+	name="Máté" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93711
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1321.1.1 = {
+		death="1321.1.1"
+	}
+}
+
+93713 = {
+	name="Máté" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93712
+	1315.1.1 = {
+		birth="1315.1.1"
+	}
+	1356.1.1 = {
+		death="1356.1.1"
+	}
+}
+
+93714 = {
+	name="Jakab" 
+	dynasty=19010
+	religion="catholic"
+	culture="hungarian"
+	father=93712
+	1318.1.1 = {
+		birth="1318.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+93715 = {
+	name="Synk"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1210.1.1 = {
+		death="1210.1.1"
+	}
+}
+
+93716 = {
+	name="Detre"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93715
+	1180.1.1 = {
+		birth="1180.1.1"
+	}
+	1236.1.1 = {
+		death="1236.1.1"
+	}
+}
+
+93717 = {
+	name="Mikó"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93716
+	1198.1.1 = {
+		birth="1198.1.1"
+	}
+	1270.1.2 = {
+		death="1270.1.2"
+	}
+}
+
+93718 = {
+	name="Miklós"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93716
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1246.1.1 = {
+		death="1246.1.1"
+	}
+}
+
+93719 = {
+	name="Detre"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93716
+	1202.1.1 = {
+		birth="1202.1.1"
+	}
+	1254.1.1 = {
+		death="1254.1.1"
+	}
+}
+
+93720 = {
+	name="Biter"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93717
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1297.1.1 = {
+		death="1297.1.1"
+	}
+}
+
+93721 = {
+	name="János"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93717
+	1250.1.1 = {
+		birth="1250.1.1"
+	}
+	1300.1.1 = {
+		death="1300.1.1"
+	}
+}
+
+93722 = {
+	name="Miklós"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93717
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1299.1.1 = {
+		death="1299.1.1"
+	}
+}
+
+93723 = {
+	name="Péter"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93717
+	1265.1.1 = {
+		birth="1265.1.1"
+	}
+	1335.1.1 = {
+		death="1335.1.1"
+	}
+}
+
+93724 = {
+	name="Mihály"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93717
+	1270.1.1 = {
+		birth="1270.1.1"
+	}
+	1300.1.1 = {
+		death="1300.1.1"
+	}
+}
+
+93725 = {
+	name="György"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93722
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1323.1.1 = {
+		death="1323.1.1"
+	}
+}
+
+93726 = {
+	name="Miklós"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93723
+	1295.1.1 = {
+		birth="1295.1.1"
+	}
+	1358.1.1 = {
+		death="1358.1.1"
+	}
+}
+
+93727 = {
+	name="János"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93723
+	1300.1.1 = {
+		birth="1300.1.1"
+	}
+	1349.1.1 = {
+		death="1349.1.1"
+	}
+}
+
+93728 = {
+	name="György"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93723
+	1305.1.1 = {
+		birth="1305.1.1"
+	}
+	1385.1.1 = {
+		death="1385.1.1"
+	}
+}
+
+
+93729 = {
+	name="Anics"
+	female=yes
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93723
+	1306.1.1 = {
+		birth="1306.1.1"
+	}
+	1335.1.1 = {
+		death="1335.1.1"
+	}
+}
+
+93730 = {
+	name="László"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93726
+	1320.1.1 = {
+		birth="1320.1.1"
+	}
+	1365.1.1 = {
+		death="1365.1.1"
+	}
+}
+
+93731 = {
+	name="Balász"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93726
+	1325.1.1 = {
+		birth="1325.1.1"
+	}
+	1388.1.1 = {
+		death="1388.1.1"
+	}
+}
+
+93732 = {
+	name="János"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93726
+	1330.1.1 = {
+		birth="1330.1.1"
+	}
+	1390.8.22 = {
+		death="1390.8.22"
+	}
+}
+
+93733 = {
+	name="Mikó"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93726
+	1335.1.1 = {
+		birth="1335.1.1"
+	}
+	1364.1.1 = {
+		death="1364.1.1"
+	}
+}
+
+93734 = {
+	name="Péter"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93718
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1307.1.1 = {
+		death="1307.1.1"
+	}
+}
+
+93735 = {
+	name="Demeter"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93718
+	1232.1.1 = {
+		birth="1232.1.1"
+	}
+	1312.6.15 = {
+		death="1312.6.15"
+	}
+}
+
+93736 = {
+	name="János"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93734
+	1255.1.1 = {
+		birth="1255.1.1"
+	}
+	1305.1.1 = {
+		death="1305.1.1"
+	}
+}
+
+93737 = {
+	name="Doncs"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93734
+	1256.1.1 = {
+		birth="1256.1.1"
+	}
+	1306.1.1 = {
+		death="1306.1.1"
+	}
+}
+
+93738 = {
+	name="Detrik"
+	dynasty=19060
+	religion="catholic"
+	culture="hungarian"
+	father=93734
+	1257.1.1 = {
+		birth="1257.1.1"
+	}
+	1307.1.1 = {
+		death="1307.1.1"
+	}
+}
+
+93747 = {
+	name="Klára"
+	female=yes
+	dynasty=12002
+	religion="catholic"
+	culture="hungarian"
+	father=93741
+	1308.1.1 = {
+		birth="1308.1.1"
+	}
+	1351.1.1 = {
+		death="1351.1.1"
+	}
+}
+
+93748 = {
+	name="János"
+	dynasty=12002
+	religion="catholic"
+	culture="hungarian"
+	father=93745
+	1328.1.1 = {
+		birth="1328.1.1"
+	}
+	1374.1.1 = {
+		death="1374.1.1"
+	}
+}
+
+93749 = {
+	name="László"
+	dynasty=12002
+	religion="catholic"
+	culture="hungarian"
+	father=93745
+	1330.1.1 = {
+		birth="1330.1.1"
+	}
+	1371.1.1 = {
+		death="1371.1.1"
+	}
+}
+
+93750 = {
+	name="Sebestyen"
+	dynasty=12002
+	religion="catholic"
+	culture="hungarian"
+	father=93746
+	1330.1.1 = {
+		birth="1330.1.1"
+	}
+	1361.1.1 = {
+		death="1361.1.1"
+	}
+}
+
+93751 = {
+	name="Gyula"
+	dynasty=7378
+	religion="catholic"
+	culture="hungarian"
+	1175.1.1 = {
+		birth="1175.1.1"
+	}
+	1226.1.1 = {
+		death="1226.1.1"
+	}
+}
+
+93752 = {
+	name="László"
+	dynasty=7378
+	religion="catholic"
+	culture="hungarian"
+	father=93751
+	1205.1.1 = {
+		birth="1205.1.1"
+	}
+	1276.1.1 = {
+		death="1276.1.1"
+	}
+}
+
+93753 = {
+	name="Gyula"
+	dynasty=7378
+	religion="catholic"
+	culture="hungarian"
+	father=93751
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1233.1.1 = {
+		death="1233.1.1"
+	}
+}
+
+93754 = {
+	name="László"
+	dynasty=7378
+	religion="catholic"
+	culture="hungarian"
+	father=93752
+	1250.1.1 = {
+		birth="1250.1.1"
+	}
+	1315.1.1 = {
+		death="1315.1.1"
+	}
+}
+
+93755 = {
+	name="Móricz"
+	dynasty=19057
+	religion="catholic"
+	culture="hungarian"
+	father=93756
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1269.1.1 = {
+		death="1269.1.1"
+	}
+}
+
+93756 = {
+	name="Móricz"
+	dynasty=19057
+	religion="catholic"
+	culture="hungarian"
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1250.1.1 = {
+		death="1250.1.1"
+	}
+}
+
+93757 = {
+	name="Sámuel"
+	# placeholder
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=20376
+	1085.1.1 = {
+		birth="1085.1.1"
+	}
+	1145.1.1 = {
+		death="1145.1.1"
+	}
+}
+
+93758 = {
+	name="János"
+	# placeholder
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=93757
+	1115.1.1 = {
+		birth="1115.1.1"
+	}
+	1180.1.1 = {
+		death="1180.1.1"
+	}
+}
+
+93759 = {
+	name="Domoszló"
+	# placeholder
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=93758
+	1150.1.1 = {
+		birth="1150.1.1"
+	}
+	1210.1.1 = {
+		death="1210.1.1"
+	}
+}
+
+93760 = {
+	name="Géza"
+	# placeholder
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=93759
+	1180.1.1 = {
+		birth="1180.1.1"
+	}
+	1240.1.1 = {
+		death="1240.1.1"
+	}
+}
+
+93761 = {
+	name="Dávid"
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=93760
+	1200.1.1 = {
+		birth="1200.1.1"
+	}
+	1260.1.1 = {
+		death="1260.1.1"
+	}
+}
+
+93762 = {
+	name="Amadé"
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=93761
+	1240.1.1 = {
+		birth="1240.1.1"
+	}
+	1311.9.5 = {
+		death="1311.9.5"
+	}
+}
+
+93763 = {
+	name="Fintá"
+	dynasty=19000
+	religion="catholic"
+	culture="hungarian"
+	father=93761
+	1245.1.1 = {
+		birth="1245.1.1"
+	}
+	1311.9.5 = {
+		death="1311.9.5"
+	}
+}
+
+93765 = {
+	name="Hencz"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93764
+	1140.1.1 = {
+		birth="1140.1.1"
+	}
+	1196.1.1 = {
+		death="1196.1.1"
+	}
+}
+
+93766 = {
+	name="Mihály"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93765
+	1165.1.1 = {
+		birth="1165.1.1"
+	}
+	1212.1.1 = {
+		death="1212.1.1"
+	}
+}
+
+93767 = {
+	name="Henrik"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93765
+	1175.1.1 = {
+		birth="1175.1.1"
+	}
+	1237.1.1 = {
+		death="1237.1.1"
+	}
+}
+
+93768 = {
+	name="Henrik"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93767
+	1210.1.1 = {
+		birth="1210.1.1"
+	}
+	1274.1.1 = {
+		death="1274.1.1"
+	}
+}
+
+93769 = {
+	name="Miklós"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93768
+	1240.1.1 = {
+		birth="1240.1.1"
+	}
+	1299.1.1 = {
+		death="1299.1.1"
+	}
+}
+
+93770 = {
+	name="János"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93768
+	1245.1.1 = {
+		birth="1245.1.1"
+	}
+	1308.5.4 = {
+		death="1308.5.4"
+	}
+}
+
+93771 = {
+	name="Péter"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93768
+	1250.1.1 = {
+		birth="1250.1.1"
+	}
+	1289.1.1 = {
+		death="1289.1.1"
+	}
+}
+
+93772 = {
+	name="Miklós"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93769
+	1275.1.1 = {
+		birth="1275.1.1"
+	}
+	1332.1.1 = {
+		death="1332.1.1"
+	}
+}
+
+93773 = {
+	name="János"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93769
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1330.1.1 = {
+		death="1330.1.1"
+	}
+}
+
+93774 = {
+	name="János"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93772
+	1300.1.1 = {
+		birth="1300.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+93775 = {
+	name="László"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93772
+	1302.1.1 = {
+		birth="1302.1.1"
+	}
+	1336.1.1 = {
+		death="1336.1.1"
+	}
+}
+
+93776 = {
+	name="Henrik"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93772
+	1310.1.1 = {
+		birth="1310.1.1"
+	}
+	1376.1.1 = {
+		death="1376.1.1"
+	}
+}
+
+93777 = {
+	name="Miklós"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93776
+	1330.1.1 = {
+		birth="1330.1.1"
+	}
+	1360.1.1 = {
+		death="1360.1.1"
+	}
+}
+
+93778 = {
+	name="András"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93776
+	1335.1.1 = {
+		birth="1335.1.1"
+	}
+	1423.1.1 = {
+		death="1423.1.1"
+	}
+}
+
+93779 = {
+	name="János"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=470150
+	1295.1.1 = {
+		birth="1295.1.1"
+	}
+	1327.1.1 = {
+		death="1327.1.1"
+	}
+}
+
+93780 = {
+	name="Miklós"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93779
+	1315.1.1 = {
+		birth="1315.1.1"
+	}
+	1358.1.1 = {
+		death="1358.1.1"
+	}
+}
+
+93781 = {
+	name="Péter"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93779
+	1317.1.1 = {
+		birth="1317.1.1"
+	}
+	1358.1.1 = {
+		death="1358.1.1"
+	}
+}
+
+93782 = {
+	name="Henrik"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93779
+	1319.1.1 = {
+		birth="1319.1.1"
+	}
+	1358.1.1 = {
+		death="1358.1.1"
+	}
+}
+
+93783 = {
+	name="Miklós"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=470150
+	1302.1.1 = {
+		birth="1302.1.1"
+	}
+	1336.1.1 = {
+		death="1336.1.1"
+	}
+}
+
+93784 = {
+	name="Péter"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=470151
+	mother=470152
+	1330.1.1 = {
+		birth="1330.1.1"
+	}
+	1405.1.1 = {
+		death="1405.1.1"
+	}
+}
+
+93785 = {
+	name="Gergely"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93770
+	1265.1.1 = {
+		birth="1265.1.1"
+	}
+	1297.1.1 = {
+		death="1297.1.1"
+	}
+}
+
+93786 = {
+	name="János"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93770
+	1270.1.1 = {
+		birth="1270.1.1"
+	}
+	1333.1.1 = {
+		death="1333.1.1"
+	}
+}
+
+93787 = {
+	name="Miklós"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93785
+	1285.1.1 = {
+		birth="1285.1.1"
+	}
+	1314.1.1 = {
+		death="1314.1.1"
+	}
+}
+
+93788 = {
+	name="András"
+	dynasty=19032
+	religion="catholic"
+	culture="hungarian"
+	father=93785
+	1290.1.1 = {
+		birth="1290.1.1"
+	}
+	1340.1.1 = {
+		death="1340.1.1"
+	}
+}
+
+93789 = {
+	name="Tamás" #real name unknown
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	1190.1.1 = {
+		birth="1190.1.1"
+	}
+	1240.1.1 = {
+		death="1240.1.1"
+	}
+}
+
+93790 = {
+	name="Barnabás"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93789
+	1210.1.1 = {
+		birth="1210.1.1"
+	}
+	1279.1.1 = {
+		death="1279.1.1"
+	}
+}
+
+93791 = {
+	name="György"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93789
+	1215.1.1 = {
+		birth="1215.1.1"
+	}
+	1265.1.1 = {
+		death="1265.1.1"
+	}
+}
+
+93792 = {
+	name="Tamás"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93790
+	1230.1.1 = {
+		birth="1230.1.1"
+	}
+	1295.1.1 = {
+		death="1295.1.1"
+	}
+}
+
+93793 = {
+	name="János"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93790
+	1232.1.1 = {
+		birth="1232.1.1"
+	}
+	1279.1.1 = {
+		death="1279.1.1"
+	}
+}
+
+93794 = {
+	name="Loránd"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93792
+	1250.1.1 = {
+		birth="1250.1.1"
+	}
+	1301.1.1 = {
+		death="1301.1.1"
+	}
+}
+
+93795 = {
+	name="István"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93792
+	1255.1.1 = {
+		birth="1255.1.1"
+	}
+	1294.1.1 = {
+		death="1294.1.1"
+	}
+}
+
+93796 = {
+	name="Jakab"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93792
+	1260.1.1 = {
+		birth="1260.1.1"
+	}
+	1325.1.1 = {
+		death="1325.1.1"
+	}
+}
+
+93797 = {
+	name="László"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93792
+	1262.1.1 = {
+		birth="1262.1.1"
+	}
+	1307.1.1 = {
+		death="1307.1.1"
+	}
+}
+
+93798 = {
+	name="Beke"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93792
+	1264.1.1 = {
+		birth="1264.1.1"
+	}
+	1326.1.1 = {
+		death="1326.1.1"
+	}
+}
+
+93799 = {
+	name="János"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93792
+	1266.1.1 = {
+		birth="1266.1.1"
+	}
+	1304.1.1 = {
+		death="1304.1.1"
+	}
+}
+
+93800 = {
+	name="István"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93794
+	1275.1.1 = {
+		birth="1275.1.1"
+	}
+	1337.1.1 = {
+		death="1337.1.1"
+	}
+}
+
+93801 = {
+	name="János"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93794
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1337.1.1 = {
+		death="1337.1.1"
+	}
+}
+
+93802 = {
+	name="László"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93794
+	1285.1.1 = {
+		birth="1285.1.1"
+	}
+	1357.1.1 = {
+		death="1357.1.1"
+	}
+}
+
+93803 = {
+	name="István"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93795
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1334.1.1 = {
+		death="1334.1.1"
+	}
+}
+
+93804 = {
+	name="István"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93795
+	1280.1.1 = {
+		birth="1280.1.1"
+	}
+	1334.1.1 = {
+		death="1334.1.1"
+	}
+}
+
+93805 = {
+	name="Bekcs"
+	dynasty=19009
+	religion="catholic"
+	culture="hungarian"
+	father=93796
+	1285.1.1 = {
+		birth="1285.1.1"
+	}
+	1319.1.1 = {
+		death="1319.1.1"
+	}
+}
+
+159135 = {
+	name="Zoltán"
+	dynasty=708
+	religion="tengri_pagan"
+	culture="hungarian"
+	father=159136
+	880.1.2={
+		birth="880.1.2"
+	}
+	955.1.2={
+		death="955.1.2"
+	}
+}
+
+159136 = {
+	name="Árpád"
+	dynasty=708
+	religion="tengri_pagan"
+	culture="hungarian"
+	father=159137
+	martial=8
+	trait=ambitious
+	trait=strong
+	trait=just
+	trait=diligent
+	trait=brilliant_strategist
+	trait=flanker
+	845.1.1={
+		birth=yes
+	}
+	907.1.1={
+		death=yes
+	}
+}
+
+159137 = {
+	name="Álmos" # Ruler of the Magyars in 845
+	dynasty=708
+	religion="tengri_pagan"
+	culture="hungarian"
+	father=159138
+	mother=159139
+	martial=8
+	diplomacy=7
+	trait=ambitious
+	trait=gregarious
+	trait=just
+	trait=patient
+	trait=brilliant_strategist
+	trait=inspiring_leader
+	
+	810.1.1 = {
+		birth = yes
+	}
+	
+	867.1.1 = {
+		# Boost the initial strength of the Magyars
+		effect = {
+			spawn_unit = {
+				province = 544 # Korsun
+				owner = ROOT
+				#leader = ROOT
+				troops = {
+					light_cavalry = { 936 936 }
+					horse_archers = { 472 472 }
+				}
+				attrition = 0.5
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 23
+				attributes = {
+					martial = 6
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				spawn_unit = {
+					province = 544 # Korsun
+					owner = ROOT
+					#leader = THIS
+					troops = {
+						light_cavalry = { 936 936 }
+						horse_archers = { 472 472 }
+					}
+					attrition = 0.5
+				}
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 27
+				attributes = {
+					martial = 6
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				spawn_unit = {
+					province = 544 # Korsun
+					owner = ROOT
+					#leader = THIS
+					troops = {
+						light_cavalry = { 936 936 }
+						horse_archers = { 472 472 }
+					}
+					attrition = 0.5
+				}
+			}
+		}
+	}
+	
+	895.1.1={
+		death = yes
+	}
+}
+
+163168 = {
+	name="Linütika"
+	dynasty=708
+	religion="tengri_pagan"
+	culture="hungarian"
+	father=159136
+	861.1.1={
+		birth="861.1.1"
+	}
+	906.1.1={
+		death="906.1.1"
+	}
+}
+
+163169 = {
+	name="Tarkatzus"
+	dynasty=708
+	religion="tengri_pagan"
+	culture="hungarian"
+	father=159136
+	864.1.1={
+		birth="864.1.1"
+	}
+	920.1.1={
+		death="920.1.1"
+	}
+}
+146214 = {
+	name="Jenö"
+	dynasty=1022386
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	741.1.1={
+		birth=yes
+	}
+	803.1.1={
+		death=yes
+	}
+}
+
+146215 = {
+	name="Dezsõ"
+	dynasty=1022386
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146214
+	758.1.1={
+		birth=yes
+	}
+	819.1.1={
+		death=yes
+	}
+}
+
+194345 = {
+	name="Elek"
+	dynasty=1022386
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146214
+	760.1.1={
+		birth=yes
+	}
+	819.1.1={
+		death=yes
+	}
+}
+
+146216 = {
+	name="Kér"
+	dynasty=1022387
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	742.1.1={
+		birth=yes
+	}
+	804.1.1={
+		death=yes
+	}
+}
+
+146217 = {
+	name="Elek"
+	dynasty=1022387
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146216
+	759.1.1={
+		birth=yes
+	}
+	820.1.1={
+		death=yes
+	}
+}
+
+146218 = {
+	name="Keszi"
+	dynasty=1022388
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	743.1.1={
+		birth=yes
+	}
+	805.1.1={
+		death=yes
+	}
+}
+
+146219 = {
+	name="Dömötör"
+	dynasty=1022388
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146218
+	760.1.1={
+		birth=yes
+	}
+	821.1.1={
+		death=yes
+	}
+}
+
+146220 = {
+	name="Kürt"
+	dynasty=1022389
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	744.1.1={
+		birth=yes
+	}
+	806.1.1={
+		death=yes
+	}
+}
+
+146221 = {
+	name="Gergely"
+	dynasty=1022389
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146220
+	761.1.1={
+		birth=yes
+	}
+	822.1.1={
+		death=yes
+	}
+}
+
+146222 = {
+	name="Gyarmat"
+	dynasty=1022390
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	745.1.1={
+		birth=yes
+	}
+	807.1.1={
+		death=yes
+	}
+}
+
+146223 = {
+	name="Attila"
+	dynasty=1022390
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146222
+	762.1.1={
+		birth=yes
+	}
+	823.1.1={
+		death=yes
+	}
+}
+
+146224 = {
+	name="Megyer"
+	dynasty=1022391
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	746.1.1={
+		birth=yes
+	}
+	808.1.1={
+		death=yes
+	}
+}
+
+146225 = {
+	name="Tivadar"
+	dynasty=1022391
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146224
+	763.1.1={
+		birth=yes
+	}
+	824.1.1={
+		death=yes
+	}
+}
+
+146226 = {
+	name="Nyék"
+	dynasty=1022392
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	747.1.1={
+		birth=yes
+	}
+	809.1.1={
+		death=yes
+	}
+}
+
+146227 = {
+	name="Zsolt"
+	dynasty=1022392
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146226
+	764.1.1={
+		birth=yes
+	}
+	825.1.1={
+		death=yes
+	}
+}
+
+146228 = {
+	name="Tarján"
+	dynasty=1022393
+	culture="hungarian"
+	religion="tengri_pagan"
+
+	748.1.1={
+		birth=yes
+	}
+	810.1.1={
+		death=yes
+	}
+}
+
+146229 = {
+	name="Tibor"
+	dynasty=1022393
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146228
+	765.1.1={
+		birth=yes
+	}
+	826.1.1={
+		death=yes
+	}
+}
+
+146230 = {
+	name="Tétény"
+	dynasty=1022386
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146215
+	783.1.1={
+		birth=yes
+	}
+	845.1.1={
+		death=yes
+	}
+}
+
+146231 = {
+	name="Töhötöm"
+	dynasty=1022386
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146230
+	809.1.1={
+		birth=yes
+	}
+	873.1.1={
+		death=yes
+	}
+}
+194367 = {
+	name="Csaba"
+	dynasty=1022386
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146231
+	840.1.1={
+		birth=yes
+	}
+	890.1.1={
+		death=yes
+	}
+}
+194368 = {
+	name="Hajnal"
+	female = yes
+	dynasty=1022386
+	culture="hungarian"
+	religion="tengri_pagan"
+	father = 146231
+	845.1.1={
+		birth=yes
+	}
+	890.1.1={
+		death=yes
+	}
+}

--- a/EMF+Vanilla/history/characters/hungarian.txt
+++ b/EMF+Vanilla/history/characters/hungarian.txt
@@ -9512,15 +9512,19 @@
 	867.1.1 = {
 		# Boost the initial strength of the Magyars
 		effect = {
-			spawn_unit = {
+			spawn_unit = { #1
 				province = 544 # Korsun
 				owner = ROOT
-				#leader = ROOT
-				troops = {
-					light_cavalry = { 936 936 }
-					horse_archers = { 472 472 }
+				troops =
+				{
+					horse_archers = { 1350 1350 }
+					light_cavalry = { 800 800 }
+					light_infantry = { 270 270 }
+					knights = { 130 130 }
 				}
-				attrition = 0.5
+				attrition = 0.25
+				merge = yes
+				earmark = start_troops
 			}
 			create_character = {
 				random_traits = yes
@@ -9530,20 +9534,26 @@
 				female = no
 				age = 23
 				attributes = {
-					martial = 6
+					martial = 10
 				}
 				trait = skilled_tactician
 			}
 			new_character = {
-				spawn_unit = {
+				give_minor_title = title_commander
+
+				spawn_unit = { #2
 					province = 544 # Korsun
 					owner = ROOT
-					#leader = THIS
-					troops = {
-						light_cavalry = { 936 936 }
-						horse_archers = { 472 472 }
+					troops =
+					{
+						horse_archers = { 1350 1350 }
+						light_cavalry = { 800 800 }
+						light_infantry = { 270 270 }
+						knights = { 130 130 }
 					}
-					attrition = 0.5
+					attrition = 0.25
+					merge = yes
+					earmark = start_troops
 				}
 			}
 			create_character = {
@@ -9554,20 +9564,116 @@
 				female = no
 				age = 27
 				attributes = {
-					martial = 6
+					martial = 10
+				}
+				trait = brilliant_strategist
+			}
+			new_character = {
+				give_minor_title = title_commander
+
+				spawn_unit = { #3
+					province = 544 # Korsun
+					owner = ROOT
+					troops =
+					{
+						horse_archers = { 1350 1350 }
+						light_cavalry = { 800 800 }
+						light_infantry = { 270 270 }
+						knights = { 130 130 }
+					}
+					attrition = 0.25
+					merge = yes
+					earmark = start_troops
+				}
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 25
+				attributes = {
+					martial = 10
 				}
 				trait = skilled_tactician
 			}
 			new_character = {
-				spawn_unit = {
+				give_minor_title = title_commander
+
+				spawn_unit = { #4
 					province = 544 # Korsun
 					owner = ROOT
-					#leader = THIS
-					troops = {
-						light_cavalry = { 936 936 }
-						horse_archers = { 472 472 }
+					troops =
+					{
+						horse_archers = { 1350 1350 }
+						light_cavalry = { 800 800 }
+						light_infantry = { 270 270 }
+						knights = { 130 130 }
 					}
-					attrition = 0.5
+					attrition = 0.25
+					merge = yes
+					earmark = start_troops
+				}
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 29
+				attributes = {
+					martial = 10
+				}
+				trait = brilliant_strategist
+			}
+			new_character = {
+				give_minor_title = title_commander
+
+				spawn_unit = { #5
+					province = 544 # Korsun
+					owner = ROOT
+					troops =
+					{
+						horse_archers = { 1350 1350 }
+						light_cavalry = { 800 800 }
+						light_infantry = { 270 270 }
+						knights = { 130 130 }
+					}
+					attrition = 0.25
+					merge = yes
+					earmark = start_troops
+				}
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 32
+				attributes = {
+					martial = 10
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				give_minor_title = title_commander
+
+				spawn_unit = { #6
+					province = 544 # Korsun
+					owner = ROOT
+					troops =
+					{
+						horse_archers = { 1350 1350 }
+						light_cavalry = { 800 800 }
+						light_infantry = { 270 270 }
+						knights = { 130 130 }
+					}
+					attrition = 0.25
+					merge = yes
+					earmark = start_troops
 				}
 			}
 		}

--- a/EMF/EMF_changelog.txt
+++ b/EMF/EMF_changelog.txt
@@ -1,10 +1,11 @@
 EMF 4.01 [BETA]
 	Crusader and Mujahid traits no longer award martial skill
-	EMF+SWMH:
+	Vanilla map: Duchy of Flanders de jure moved to Kingdom of France
+	SWMH map:
 		Manual advancement of start date in the game lobby has been extended to 1337.1.1, like vanilla (still no bookmarks after 1205, though)
 		Castle cultural buildings and cultural retinues have been added for the new German sub-cultures in SWMH, along with the Szekely
 		Gothic/Geat culture now has a heavy infantry cultural retinue
-		Cultural modifiers have been simplified and better balanced
+		Cultural modifiers have been streamlined and balanced
 		FIX: Romanian and Albanians will no longer have two different cultural buildings, and Albanians now have a retinue
 		FIX: Robert Guiscard no longer has an overlapping war (2 CBs at once) in the Alexiad (1081) start
 		MINOR: De jure Irish kingdom title no longer automatically destroyed upon scenario start; this should no longer be an issue with SWMH
@@ -15,9 +16,9 @@ EMF 4.01 [BETA]
 		Mongol Empire will no longer convert away from the Tengri faith until at least 30 years after its arrival.
 		The *Conqueror* trait (which makes characters particularly ruthless) will stop being applied to Mongol invaders after the year 1300
 	Elective monarchy faction logic significantly improved, toward the goal of generally reducing the faction's likelihood to revolt
+	Magyar starting troops in 867 are now sufficient to beat Bulgaria and properly wreak some havoc on Eastern Europe
 	Robert Guiscard's 5 Norman-Byzantine Wars from 1066 until his death have been removed in favor of an invasion of the Balkans in 1081.4.1 (Alexiad start), for historical accuracy
 		However, it is likely that his earlier Italian campaigns against the ERE will receive special treatment (with a custom CB) in the future.
-	Vanilla map: Duchy of Flanders de jure moved to Kingdom of France
 	Rewrote *Remove Ahistorical Empires* scenario customization for more simplicity and robustness
 		FIX: Will no longer deactivate an ahistorical empire title if it is actually held (but will still make it titular-- notably affects Abbasids in 769)
 	Upon settlement, nomads spawn 3x less event troops proportional to number of empty holding slots abandoned

--- a/EMF/EMF_changelog.txt
+++ b/EMF/EMF_changelog.txt
@@ -26,6 +26,7 @@ EMF 4.01 [BETA]
 	FIX: *Adopt Feudalism* decision should now always be enabled when its tooltip indicates that it should be
 	FIX: The Seljuks will no longer immediately lose their titular empire-tier title gained when they first spawn/invade (pre-1066 starts)
 	FIX: Some misfiring PB events related to 'retaking the coast' and the Bulgarian unrest have been removed temporarily due to misbehavior
+	FIX: All those eligible to be marshals are now also eligible to receive the Commander minor title (prior, many EMF extensions to command eligibility were disregarded)
 	VANILLA FIX: Reduced the odds of an AI character with theology focus taking the option to become a heretic from 33% to 20%
 	VANILLA FIX: (Hopefully) stopped spurious 'minor clan reinforcements' event for unrelated provincial revolts (stopgap)
 	VANILLA FIX: Upon scenario initialization, virtually every king-tier title in the game is given an [uncreatable] placeholder de jure empire when they otherwise lack a de jure empire

--- a/EMF/common/minor_titles/00_minor_titles.txt
+++ b/EMF/common/minor_titles/00_minor_titles.txt
@@ -158,23 +158,55 @@ title_commander = {
 	monthly_prestige = 0.025
 	
 	allowed_to_hold = {
-		OR = {
-			AND = {
-				OR = {
-					is_female = no
-					AND = {
-						OR = {
-							religion = cathar
-							religion = messalian
-						}
-						OR = {
-							liege = { religion = cathar }
-							liege = { religion = messalian }
+		or = {
+			is_female = no
+			and = {
+				religion = cathar
+				liege = { religion = cathar }
+			}
+			liege = {
+				primary_title = { # EMF: Absolute Cognatic opens up all council seats to women (except Lord Spiritual)
+					or = {
+						has_law = true_cognatic_succession
+						has_law = enatic_cognatic_succession
+						has_law = enatic_succession
+					}
+				}
+			}
+			has_character_flag = special_marshal
+			and = {
+				has_global_flag = gender_equality
+				not = { liege = { religion_group = muslim } }
+			}
+			and = { # EMF: Norse women are allowed to lead troops
+				or = {
+					culture = norse
+					and = {
+						culture_group = north_germanic
+						or = {
+							religion = norse_pagan
+							religion = norse_pagan_reformed
 						}
 					}
 				}
-				OR = {
-					NOT = { religion = hindu }
+				liege = {
+					or = {
+						culture = norse
+						and = {
+							culture_group = north_germanic
+							or = {
+								religion = norse_pagan
+								religion = norse_pagan_reformed
+							}
+						}
+					}
+				}
+			}
+		}
+		or = {
+			and = {
+				or = {
+					not = { religion = hindu }
 					trait = kshatriya
 				}
 				is_adult = yes
@@ -183,9 +215,9 @@ title_commander = {
 		}
 		
 		prisoner = no
-		NOT = { trait = incapable }
-		NOT = { trait = in_hiding }
-		NOT = { has_character_flag = guru }
+		not = { trait = incapable }
+		not = { trait = in_hiding }
+		not = { has_character_flag = guru }
 	}
 	
 	gain_effect = {

--- a/EMF/common/minor_titles/00_minor_titles.txt
+++ b/EMF/common/minor_titles/00_minor_titles.txt
@@ -1,0 +1,2308 @@
+########################################################
+# MINOR TITLES
+# Characters can have any number of these
+########################################################
+#	grant_limit: Max number of holders.
+#	realm_in_name: Append the name of the country after the title (Queen [of Sweden])
+#	allowed_to_hold: conditions for the character to hold the title
+#	allowed_to_grant: conditions for a ruler to grant the title
+#	regent: This is the title for regents (not really "minor")
+#	gain_effect: fires when the title is granted
+#	lose_effect: fires when a title is lost if dismissal_trigger evaluates to false
+#	message: should fire a message to the its owner when set
+#	The other fields are all character modifiers.
+
+#######################################
+# HARD: AUTO-GRANTED - DO NOT REMOVE!
+#######################################
+
+title_regent = {
+	realm_in_name = yes
+	dignity = 0.9
+	revoke_allowed = no
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.02
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_appointed_regent = {
+	dignity = 0.9
+	grant_limit = 1
+	opinion_effect = 20
+	revoke_allowed = yes
+
+	monthly_salary = 0.05
+	monthly_prestige = 0.02
+
+	allowed_to_hold = {
+		is_adult = yes
+		prisoner = no
+		has_regent = no
+	}
+	
+	allowed_to_grant = {
+		has_regent = no
+	}
+
+	gain_effect = {
+	}
+
+	lose_effect = {
+	}
+}
+
+title_ruler_consort = {
+	dignity = 0.88
+	show_as_title = yes
+	realm_in_name = yes
+	spouse_context = yes # Title name as if the other gender version of the spouse's ruler title
+	revoke_allowed = no
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.02
+	
+	gain_effect = {
+	}
+	
+	lose_effect = {
+	}
+
+	message = no
+}
+
+title_tanist = {
+	dignity = 0.86
+	show_as_title = yes
+	realm_in_name = yes
+	revoke_allowed = no
+	
+	monthly_salary = 0.07
+	monthly_prestige = 0.02
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = no
+}
+
+title_queen_mother = {
+	dignity = 0.85
+	show_as_title = yes
+	realm_in_name = yes
+	revoke_allowed = no
+	
+	monthly_salary = 0.05
+	monthly_prestige = 0.01
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = no
+}
+
+title_prince = {
+	dignity = 0.8
+	show_as_title = yes
+	realm_in_name = yes
+	revoke_allowed = no
+	
+	monthly_salary = 0.05
+	monthly_prestige = 0.01
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = no
+}
+
+# Pagan consort
+title_courtesan = {
+	dignity = 0.05
+	realm_in_name = yes
+	revoke_allowed = no
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.01
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = no
+}
+
+# Commander, granted via its own interaction, so very special
+title_commander = {
+	is_high_prio = yes
+	
+	attribute = martial
+	dignity = 0.05
+	opinion_effect = 10
+	realm_in_name = yes
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.025
+	
+	allowed_to_hold = {
+		OR = {
+			AND = {
+				OR = {
+					is_female = no
+					AND = {
+						OR = {
+							religion = cathar
+							religion = messalian
+						}
+						OR = {
+							liege = { religion = cathar }
+							liege = { religion = messalian }
+						}
+					}
+				}
+				OR = {
+					NOT = { religion = hindu }
+					trait = kshatriya
+				}
+				is_adult = yes
+			}
+			has_character_flag = special_marshal
+		}
+		
+		prisoner = no
+		NOT = { trait = incapable }
+		NOT = { trait = in_hiding }
+		NOT = { has_character_flag = guru }
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+	
+	message = yes
+}
+
+#######################################
+# SOFT: GRANTABLE - FULLY MODDABLE
+#######################################
+
+title_court_eunuch = {
+	dignity = 0.01
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.01
+	
+	allowed_to_hold = {
+		is_adult = yes
+		trait = eunuch
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		primary_title = {
+			OR = {
+				tier = king
+				tier = emperor
+			}
+		}
+		NOT = { has_landed_title = e_byzantium }
+		NOT = { has_landed_title = e_roman_empire }
+	}
+	
+	gain_effect = {
+		FROM = {
+			prestige = 10
+		}
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_court_dwarf = {
+	dignity = 0.01
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.01
+	
+	allowed_to_hold = {
+		is_adult = yes
+		trait = dwarf
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		primary_title = {
+			OR = {
+				tier = king
+				tier = emperor
+			}
+		}	
+	}
+	
+	gain_effect = {
+		FROM = {
+			prestige = 10
+		}
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_court_jester = {
+	dignity = 0.01
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = -10
+	
+	monthly_salary = 0.02
+	monthly_prestige = -0.01
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		NOT = { has_character_flag = guru }
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		primary_title = {
+			OR = {
+				tier = king
+				tier = emperor
+			}
+		}
+		OR = {
+			religion_group = christian
+			religion_group = jewish_group
+			religion_group = pagan_group
+			religion_group = indian_group
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+# Keeper of the King's Swans
+title_keeper_of_swans = {
+	dignity = 0.05
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.01
+	monthly_prestige = 0.002
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		primary_title = {
+			OR = {
+				tier = king
+				tier = emperor
+			}
+		}
+		NOT = { has_landed_title = e_byzantium }
+		NOT = { has_landed_title = e_roman_empire }
+		OR = {
+			religion_group = christian
+			religion_group = jewish_group
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_master_of_the_horse = {
+	dignity = 0.06
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.004
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		NOT = { has_landed_title = e_byzantium }
+		NOT = { has_landed_title = e_roman_empire }
+		OR = {
+			religion_group = christian
+			religion_group = jewish_group
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_master_of_the_hunt = {
+	dignity = 0.05
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.004
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		NOT = { has_character_flag = guru }
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		NOT = { has_landed_title = e_byzantium }
+		NOT = { has_landed_title = e_roman_empire }
+		OR = {
+			religion_group = christian
+			religion_group = jewish_group
+			religion_group = indian_group
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_high_almoner = {
+	dignity = 0.03
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.004
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		NOT = { has_landed_title = e_byzantium }
+		NOT = { has_landed_title = e_roman_empire }
+		OR = {
+			religion_group = christian
+			religion_group = jewish_group
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_cupbearer = {
+	dignity = 0.1
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.05
+	monthly_prestige = 0.006
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		NOT = { has_character_flag = guru }
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		NOT = { has_landed_title = e_byzantium }
+		NOT = { has_landed_title = e_roman_empire }
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_seneschal = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.05
+	monthly_prestige = 0.006
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		NOT = { has_character_flag = guru }
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		primary_title = {
+			OR = {
+				tier = king
+				tier = emperor
+			}
+		}
+		NOT = { has_landed_title = e_byzantium }
+		NOT = { has_landed_title = e_roman_empire }
+		OR = {
+			religion_group = christian
+			religion_group = jewish_group
+			religion_group = indian_group
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_paramount_knight = {
+	dignity = 0.8
+	grant_limit = 0 
+	opinion_effect = 0
+
+	monthly_prestige = 0.5
+
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+# Byzantine Titles
+title_despot = {
+	dignity = 0.25
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 25
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.01
+	
+	counts_as_purple_born = yes
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_female = no
+		is_close_relative = FROM
+	}
+	
+	allowed_to_grant = {
+		is_feudal = yes
+		OR = {
+			has_landed_title = e_byzantium
+			has_landed_title = e_roman_empire
+		}
+		OR = {
+			religion_group = christian
+			religion_group = jewish_group
+			religion_group = pagan_group
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_sebastokrator = {
+	dignity = 0.2
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 20
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.01
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_close_relative = FROM
+	}
+	
+	allowed_to_grant = {
+		is_feudal = yes
+		OR = {
+			has_landed_title = e_byzantium
+			has_landed_title = e_roman_empire
+		}
+		OR = {
+			religion_group = christian
+			religion_group = jewish_group
+			religion_group = pagan_group
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_caesar = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.01
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		always = yes
+	}
+	
+	allowed_to_grant = {
+		is_feudal = yes
+		OR = {
+			has_landed_title = e_byzantium
+			has_landed_title = e_roman_empire
+		}
+		OR = {
+			religion_group = christian
+			religion_group = jewish_group
+			religion_group = pagan_group
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_kouropalates = {
+	dignity = 0.10
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.075
+	monthly_prestige = 0.075
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = nn
+	}
+	
+	allowed_to_grant = {
+		is_feudal = yes
+		OR = {
+			has_landed_title = e_byzantium
+			has_landed_title = e_roman_empire
+		}
+		OR = {
+			religion_group = christian
+			religion_group = jewish_group
+			religion_group = pagan_group
+		}
+	}
+		
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_anthypatos = {
+	dignity = 0.075
+	grant_limit = 4
+	opinion_effect = 10
+	
+	monthly_salary = 0.005
+	monthly_prestige = 0.005
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+	
+	allowed_to_grant = {
+		is_feudal = yes
+		OR = {
+			has_landed_title = e_byzantium
+			has_landed_title = e_roman_empire
+		}
+		OR = {
+			religion_group = christian
+			religion_group = jewish_group
+			religion_group = pagan_group
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_imperial_eunuch = {
+	dignity = 0.050
+	grant_limit = 1
+	opinion_effect = 60
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.01
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		trait = eunuch
+	}
+	
+	allowed_to_grant = {
+		is_feudal = yes
+		OR = {
+			religion_group = christian
+			religion_group = jewish_group
+			religion_group = pagan_group
+		}
+		OR = {
+			has_landed_title = e_byzantium
+			has_landed_title = e_roman_empire
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+# Muslim World titles
+
+title_food_taster = {
+	dignity = 0.01
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = -10
+	
+	monthly_salary = 0.02
+	monthly_prestige = -0.01
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		primary_title = {
+			OR = {
+				tier = king
+				tier = emperor
+			}
+		}
+		religion_group = muslim
+	}
+		
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_court_calligrapher = {
+	dignity = 0.05
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.01
+	monthly_prestige = 0.002
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		primary_title = {
+			OR = {
+				tier = king
+				tier = emperor
+			}
+		}
+		religion_group = muslim
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_court_musician = {
+	dignity = 0.06
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.004
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		OR = {
+			religion_group = muslim
+			religion_group = indian_group
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_court_poet = {
+	dignity = 0.05
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.004
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		religion_group = muslim
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_chief_architect = {
+	dignity = 0.03
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.004
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		religion_group = muslim
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_chief_qadi = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.05
+	monthly_prestige = 0.006
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		religion_group = muslim
+		liege = { religion = PREV }
+		OR = {
+			trait = detached_priest
+			trait = martial_cleric
+			trait = scholarly_theologian
+			trait = mastermind_theologian
+		}
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		primary_title = {
+			OR = {
+				tier = king
+				tier = emperor
+			}
+		}
+		religion_group = muslim
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+
+# MERCHANT REPUBLIC TITLES
+
+# State Inquisitor
+title_state_inquisitor = {
+	dignity = 0.06
+	realm_in_name = yes
+	grant_limit = 3
+	opinion_effect = 12
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.004
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+
+	allowed_to_grant = {
+		is_merchant_republic = yes
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_high_admiral = {
+	dignity = 0.1
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.05
+	monthly_prestige = 0.006
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+	
+	allowed_to_grant = {
+		is_merchant_republic = yes
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_high_judge = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.05
+	monthly_prestige = 0.006
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+
+	allowed_to_grant = {
+		is_merchant_republic = yes
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+# Special - This title determines the heir of a Patrician
+title_patrician_heir = {
+	is_high_prio = yes
+	
+	dignity = 0.05
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 50
+	
+	patrician_heir = yes
+	
+	monthly_salary = 0.01
+	monthly_prestige = 0.002
+	
+	allowed_to_hold = {
+		is_female = no
+		dynasty = FROM
+		NOT = { trait = bastard }
+	}
+
+	allowed_to_grant = {
+		is_patrician = yes
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+# NORSE PAGAN TITLES
+
+title_volva = {
+	dignity = 0.050
+	grant_limit = 1
+	opinion_effect = 5
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.01
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = yes
+		trait = mystic
+		OR = {
+			religion = norse_pagan
+			religion = norse_pagan_reformed
+		}
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			religion = norse_pagan
+			religion = norse_pagan_reformed
+		}
+	}
+		
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_lawspeaker = {
+	dignity = 0.2
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 20
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.075
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		OR = {
+			religion = norse_pagan
+			religion = norse_pagan_reformed
+		}
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		OR = {
+			religion = norse_pagan
+			religion = norse_pagan_reformed
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_drottseti = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.05
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		OR = {
+			religion = norse_pagan
+			religion = norse_pagan_reformed
+		}
+		higher_tier_than = DUKE
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_court_skald = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.075
+	monthly_prestige = 0.075
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		trait = poet
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		OR = {
+			religion = norse_pagan
+			religion = norse_pagan_reformed
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_marksman = {
+	dignity = 0.1
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.075
+	monthly_prestige = 0.075
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		OR = {
+			religion = norse_pagan
+			religion = norse_pagan_reformed
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_hirdman = {
+	dignity = 0.075
+	grant_limit = 4
+	opinion_effect = 10
+	
+	monthly_salary = 0.005
+	monthly_prestige = 0.005
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		OR = {
+			religion = norse_pagan
+			religion = norse_pagan_reformed
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+# MONGOL PAGAN TITLES
+
+title_baghatur = {
+	dignity = 0.2
+	realm_in_name = yes
+	grant_limit = 2
+	opinion_effect = 20
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.075
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+	}
+
+	allowed_to_grant = {
+		OR = {
+			AND = {
+				is_nomadic = yes
+				culture = mongol
+			}
+			AND = {
+				OR = {
+					is_feudal = yes
+					is_tribal = yes
+				}
+				OR = {
+					has_landed_title = e_mongol_empire
+					has_landed_title = e_golden_horde
+					has_landed_title = e_il-khanate
+				}
+			}
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_cherbi = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.05
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+	}
+
+	allowed_to_grant = {
+		OR = {
+			AND = {
+				is_nomadic = yes
+				culture = mongol
+			}
+			AND = {
+				OR = {
+					is_feudal = yes
+					is_tribal = yes
+				}
+				OR = {
+					has_landed_title = e_mongol_empire
+					has_landed_title = e_golden_horde
+					has_landed_title = e_il-khanate
+				}
+			}
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_darkhan = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 2
+	opinion_effect = 15
+	
+	monthly_salary = 0.075
+	monthly_prestige = 0.075
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+	}
+
+	allowed_to_grant = {
+		OR = {
+			AND = {
+				is_nomadic = yes
+				culture = mongol
+			}
+			AND = {
+				OR = {
+					is_feudal = yes
+					is_tribal = yes
+				}
+				OR = {
+					has_landed_title = e_mongol_empire
+					has_landed_title = e_golden_horde
+					has_landed_title = e_il-khanate
+				}
+			}
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_noyan = {
+	dignity = 0.075
+	grant_limit = 4
+	opinion_effect = 10
+	
+	monthly_salary = 0.005
+	monthly_prestige = 0.005
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		OR = {
+			has_landed_title = e_mongol_empire
+			has_landed_title = e_golden_horde
+			has_landed_title = e_il-khanate
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_behi = {
+	dignity = 0.1
+	grant_limit = 2
+	opinion_effect = 10
+	
+	monthly_salary = 0.05
+	monthly_prestige = 0.1
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = yes
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			AND = {
+				is_nomadic = yes
+				culture = mongol
+			}
+			AND = {
+				OR = {
+					is_feudal = yes
+					is_tribal = yes
+				}
+				OR = {
+					has_landed_title = e_mongol_empire
+					has_landed_title = e_golden_horde
+					has_landed_title = e_il-khanate
+				}
+			}
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_master_of_the_eagle = {
+	dignity = 0.10
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.15
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			AND = {
+				is_nomadic = yes
+				culture = mongol
+			}
+			AND = {
+				OR = {
+					is_feudal = yes
+					is_tribal = yes
+				}
+				OR = {
+					has_landed_title = e_mongol_empire
+					has_landed_title = e_golden_horde
+					has_landed_title = e_il-khanate
+				}
+			}
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+
+# ZOROASTRIAN TITLES
+
+title_shahrwaraz = {
+	dignity = 0.2
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 20
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.075
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		martial = 15
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		religion_group = zoroastrian_group
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_kardarigan = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.075
+	monthly_prestige = 0.075
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		martial = 15
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		religion_group = zoroastrian_group
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_shahin = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.075
+	monthly_prestige = 0.075
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		martial = 15
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		religion_group = zoroastrian_group
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_pushtigban_salar = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.05
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		religion_group = zoroastrian_group
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_spahbod = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 4
+	opinion_effect = 15
+	
+	monthly_salary = 0.075
+	monthly_prestige = 0.075
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+
+	allowed_to_grant = {
+		higher_tier_than = DUKE
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		religion_group = zoroastrian_group
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_eran_ambaragbed = {
+	dignity = 0.075
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.005
+	monthly_prestige = 0.005
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		religion_group = zoroastrian_group
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+# GENERIC PAGAN TITLES
+
+title_champion = {
+	dignity = 0.2
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 20
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.075
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		OR = {
+			religion = baltic_pagan_reformed
+			religion = baltic_pagan
+			religion = finnish_pagan_reformed
+			religion = finnish_pagan
+			religion = slavic_pagan_reformed
+			religion = slavic_pagan
+			religion = west_african_pagan_reformed
+			religion = west_african_pagan
+			religion = aztec_reformed
+			religion = aztec
+			religion = zun_pagan_reformed
+			religion = zun_pagan
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_master_of_the_blade = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.075
+	monthly_prestige = 0.075
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		NOT = { has_minor_title = title_master_of_the_bow }
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		NOT = {
+			OR = {
+				has_landed_title = e_mongol_empire
+				has_landed_title = e_golden_horde
+				has_landed_title = e_il-khanate
+			}
+		}
+		OR = {
+			religion = baltic_pagan_reformed
+			religion = baltic_pagan
+			religion = finnish_pagan_reformed
+			religion = finnish_pagan
+			religion = slavic_pagan_reformed
+			religion = slavic_pagan
+			religion = west_african_pagan_reformed
+			religion = west_african_pagan
+			religion = aztec_reformed
+			religion = aztec
+			religion = tengri_pagan
+			religion = tengri_pagan_reformed
+			religion = zun_pagan_reformed
+			religion = zun_pagan
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_master_of_the_bow = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.075
+	monthly_prestige = 0.075
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		NOT = { has_minor_title = title_master_of_the_blade }
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		NOT = {
+			OR = {
+				has_landed_title = e_mongol_empire
+				has_landed_title = e_golden_horde
+				has_landed_title = e_il-khanate
+			}
+		}
+		OR = {
+			religion = baltic_pagan_reformed
+			religion = baltic_pagan
+			religion = finnish_pagan_reformed
+			religion = finnish_pagan
+			religion = slavic_pagan_reformed
+			religion = slavic_pagan
+			religion = west_african_pagan_reformed
+			religion = west_african_pagan
+			religion = aztec_reformed
+			religion = aztec
+			religion = tengri_pagan
+			religion = tengri_pagan_reformed
+			religion = zun_pagan_reformed
+			religion = zun_pagan
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_venerable_elder = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 4
+	opinion_effect = 15
+	
+	monthly_salary = 0.075
+	monthly_prestige = 0.075
+	
+	allowed_to_hold = {
+		is_female = no
+		age = 50
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		NOT = {
+			OR = {
+				has_landed_title = e_mongol_empire
+				has_landed_title = e_golden_horde
+				has_landed_title = e_il-khanate
+			}
+		}
+		OR = {
+			religion = baltic_pagan_reformed
+			religion = baltic_pagan
+			religion = finnish_pagan_reformed
+			religion = finnish_pagan
+			religion = slavic_pagan_reformed
+			religion = slavic_pagan
+			religion = west_african_pagan_reformed
+			religion = west_african_pagan
+			religion = aztec_reformed
+			religion = aztec
+			religion = tengri_pagan
+			religion = tengri_pagan_reformed
+			religion = zun_pagan_reformed
+			religion = zun_pagan
+		}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+# TENGRI TITLES:
+
+title_yabgu = {
+	dignity = 0.25
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 25
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.01
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		is_close_relative = FROM
+	}
+
+	allowed_to_grant = {
+		#OR = {
+		#	AND = {
+				is_nomadic = yes
+				NOT = { culture = mongol }
+		#	}
+		#	AND = {
+		#		OR = {
+		#			is_feudal = yes
+		#			is_tribal = yes
+		#		}
+		#		NOT = {
+		#			OR = {
+		#				has_landed_title = e_mongol_empire
+		#				has_landed_title = e_golden_horde
+		#				has_landed_title = e_il-khanate
+		#			}
+		#		}
+		#		OR = {
+		#			religion = tengri_pagan
+		#			religion = tengri_pagan_reformed
+		#		}
+		#	}
+		#}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_ishad = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 4
+	opinion_effect = 15
+	
+	monthly_salary = 0.075
+	monthly_prestige = 0.075
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+	}
+
+	allowed_to_grant = {
+		#OR = {
+		#	AND = {
+				is_nomadic = yes
+				NOT = { culture = mongol }
+		#	}
+		#	AND = {
+		#		OR = {
+		#			is_feudal = yes
+		#			is_tribal = yes
+		#		}
+		#		NOT = {
+		#			OR = {
+		#				has_landed_title = e_mongol_empire
+		#				has_landed_title = e_golden_horde
+		#				has_landed_title = e_il-khanate
+		#			}
+		#		}
+		#		OR = {
+		#			religion = tengri_pagan
+		#			religion = tengri_pagan_reformed
+		#		}
+		#	}
+		#}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_kundur = {
+	dignity = 0.15
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 15
+	
+	monthly_salary = 0.1
+	monthly_prestige = 0.05
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+	}
+	
+	allowed_to_grant = {
+		#OR = {
+		#	AND = {
+				is_nomadic = yes
+				NOT = { culture = mongol }
+		#	}
+		#	AND = {
+		#		OR = {
+		#			is_feudal = yes
+		#			is_tribal = yes
+		#		}
+		#		NOT = {
+		#			OR = {
+		#				has_landed_title = e_mongol_empire
+		#				has_landed_title = e_golden_horde
+		#				has_landed_title = e_il-khanate
+		#			}
+		#		}
+		#		OR = {
+		#			religion = tengri_pagan
+		#			religion = tengri_pagan_reformed
+		#		}
+		#	}
+		#}
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+# INDIAN TITLES
+
+title_master_of_the_royal_elephants = {
+	dignity = 0.06
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.004
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		NOT = { has_character_flag = guru }
+	}
+	
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		primary_title = {
+			OR = {
+				tier = king
+				tier = emperor
+			}
+		}
+		NOT = { has_landed_title = e_byzantium }
+		NOT = { has_landed_title = e_roman_empire }
+		religion_group = indian_group
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_royal_builder = {
+	dignity = 0.03
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.004
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		NOT = { has_character_flag = guru }
+	}
+
+	allowed_to_grant = {
+		is_feudal = yes
+		primary_title = {
+			OR = {
+				tier = king
+				tier = emperor
+			}
+		}
+		religion_group = indian_group
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_court_poet_india = {
+	dignity = 0.05
+	realm_in_name = yes
+	grant_limit = 1
+	opinion_effect = 10
+	
+	monthly_salary = 0.02
+	monthly_prestige = 0.004
+	
+	is_unique = yes
+	
+	allowed_to_hold = {
+		is_adult = yes
+		is_female = no
+		NOT = { has_character_flag = guru }
+	}
+
+	allowed_to_grant = {
+		OR = {
+			is_feudal = yes
+			is_tribal = yes
+		}
+		religion_group = indian_group
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+
+title_guru = {
+	dignity = 0.050
+	grant_limit = 1
+	opinion_effect = 15
+	monthly_salary = 0.02
+	monthly_prestige = 0.1
+
+	revoke_allowed = no
+	
+	allowed_to_hold = {
+		OR = {
+			has_character_flag = guru
+			has_character_flag = fake_guru
+		}
+		is_adult = yes
+		religion_group = indian_group
+	}
+	
+	allowed_to_grant = { 
+		religion_group = indian_group 
+	}
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+
+	message = yes
+}
+title_genghis = {
+	dignity = 10
+	revoke_allowed = no
+	
+	realm_in_name = no
+	show_as_title = yes
+	
+	replace_order = yes
+	
+	monthly_salary = 0
+	monthly_prestige = 0.1
+	
+	gain_effect = {
+	}
+	lose_effect = {
+	}
+	
+	message = yes
+}


### PR DESCRIPTION
- Rebalanced 867 starting troops of Magyars for both vanilla and SWMH maps
- Fixed issue where `title_commander`'s `allowed_to_hold` was vanilla rather than EMF's command eligibility conditions (`job_marshal`'s `allow`)