### PR TITLE
Nomad settlement improvement

### DIFF
--- a/EMF/EMF_changelog.txt
+++ b/EMF/EMF_changelog.txt
@@ -4,7 +4,7 @@ EMF 4.02 [BETA]
 			CB is currently now AI-only, but a player version will be added again.
 			The CB is now valid until 967 (100 years from start and 2 years after the historical formation)
 			Most of its additional permissiveness is not valid vs. player targets.
-			Lucky Rulers are able to use it under many more circumstances than others.
+			Lucky Rulers are able to use it under many more circumstances than others and will thus be considerably more likely to be able to form the HRE, if they're king of one of the de jure kingdom titles that once constituted the Carolingien Empire (France, Aquitaine, Italy, Lotharingia, Burgundy, Germany, and Bavaria).
 			Expanded target kingdom preference modifiers to promote better borders, more plausible conquest
 			(EMF+SWMH) FIX: All of the new German subcultures in SWMH can use it
 		(EMF+SWMH) FIX: When forming the western/Frankish HRE, Duchy of Alsace is now properly a de jure vassal of the empire (but Alsace still transfers to the standard/German HRE if it is formed instead)
@@ -19,6 +19,8 @@ EMF 4.02 [BETA]
 			Italy
 			Holy Roman Empire [Standard HRE]
 			Saint-Empire Romain [Western HRE]
+	Nomads:
+		Upon settlement as feudal, players now only retain prior demesne nomadic provinces that are actually directly-connected to their new realm, and any otherwise isolated nomadic provinces go with the new leader of their prior nomadic title. [In vanilla, all nomadic demesne provinces are lost, and in the prior version of EMF, all were retained.]
 
 
 EMF 4.01 [2015-09-01]

--- a/EMF/events/emf_nomad.txt
+++ b/EMF/events/emf_nomad.txt
@@ -1,7 +1,11 @@
 
 namespace = emf_nomad
 
-
+# emf_nomad.0 [Settling Nomad]
+#
+# Invoked by nomad settlement decisions, prior to conversion to non-nomadic
+# government. Determines how many provinces in the new realm will be "settled"
+# (converted to culture & religion of nomad).
 character_event = {
 	id = emf_nomad.0
 	hide_window = yes
@@ -89,36 +93,44 @@ character_event = {
 }
 
 
+# emf_nomad.1 [Settling Ex-Nomad]
+#
+# Continuation of emf_nomad.0, invoked after change to non-nomadic government.
 character_event = {
-    id = emf_nomad.1
-    hide_window = yes
-    is_triggered_only = yes
+	id = emf_nomad.1
+	hide_window = yes
+	is_triggered_only = yes
 
-    immediate = {
-        # Settle new capital ...
+	immediate = {
+		# Settle new capital ...
 
-        capital_scope = {
-            religion = ROOT
-            culture = ROOT
-            set_province_flag = emf_nomad_settled
-        }
+		capital_scope = {
+			religion = ROOT
+			culture = ROOT
+			set_province_flag = emf_nomad_settled
+		}
 
-        # Settle up to `n_convert` provinces with our religion/culture via
-        # "cluster-blobbing" technique, starting at new capital ...
+		# Settle up to `n_convert` provinces with our religion/culture via
+		# "cluster-blobbing" technique, starting at new capital ...
 
-        character_event = { id = emf_nomad.2 }
+		character_event = { id = emf_nomad.2 }
 
-        # Cleanup ...
+		# Cleanup ...
 
-        any_realm_province = {
-            clr_province_flag = emf_nomad_settled
-        }
+		any_realm_province = {
+			clr_province_flag = emf_nomad_settled
+		}
 
-        set_variable = { which = n_convert value = 0 }
-    }
+		set_variable = { which = n_convert value = 0 }
+	}
 }
 
 
+# emf_nomad.2 [Settling Ex-Nomad]
+#
+# The guts of emf_nomad.1: Recursive "cluster-blobbing" algorithm that focuses
+# upon "converting" contiguous group(s) of provinces in a random yet plausible
+# manner.
 character_event = {
 	id = emf_nomad.2
 	hide_window = yes
@@ -132,188 +144,255 @@ character_event = {
 		name = OK
 
 		random_realm_province = {
-            limit = {
-                has_province_flag = emf_nomad_settled
-                any_neighbor_province = {
-                    nand = {
-                        religion = ROOT
-                        culture = ROOT
-                    }
-                    any_province_holding = {
-                        not = { holding_type = nomad }
-                    }
-                    owner = {
-                        or = {
-                            character = ROOT
-                            is_liege_or_above = ROOT
-                        }
-                    }
-                }
-            }
+			limit = {
+				has_province_flag = emf_nomad_settled
+				any_neighbor_province = {
+					nand = {
+						religion = ROOT
+						culture = ROOT
+					}
+					any_province_holding = {
+						not = { holding_type = nomad }
+					}
+					owner = {
+						same_realm = ROOT
+					}
+				}
+			}
 
-            # Mark any already same-religion/culture neighbors as settled,
-            # but don't count them towards conversion total.
-            any_neighbor_province = {
-                limit = {
-                    religion = ROOT
-                    culture = ROOT
-                    any_province_holding = {
-                        not = { holding_type = nomad }
-                    }
-                    owner = {
-                        or = {
-                            character = ROOT
-                            is_liege_or_above = ROOT
-                        }
-                    }
-                }
-                set_province_flag = emf_nomad_settled
-            }
+			# Mark any already same-religion/culture neighbors as settled,
+			# but don't count them towards conversion total.
+			any_neighbor_province = {
+				limit = {
+					religion = ROOT
+					culture = ROOT
+					any_province_holding = {
+						not = { holding_type = nomad }
+					}
+					owner = {
+						same_realm = ROOT
+					}
+				}
+				set_province_flag = emf_nomad_settled
+			}
 
-            # Select a random eligible neighbor province to settle
-            random_neighbor_province = {
-                limit = {
-                    nand = {
-                        religion = ROOT
-                        culture = ROOT
-                    }
-                    any_province_holding = {
-                        not = { holding_type = nomad }
-                    }
-                    owner = {
-                        or = {
-                            character = ROOT
-                            is_liege_or_above = ROOT
-                        }
-                    }
-                }
-                religion = ROOT
-                culture = ROOT
-                set_province_flag = emf_nomad_settled
-                ROOT = {
-                    change_variable = { which = n_convert value = -1 }
-                    character_event = { id = emf_nomad.2 } # Recurse
-                    break = yes # <-- Very important
-                }
-            }
-        }
+			# Select a random eligible neighbor province to settle
+			random_neighbor_province = {
+				limit = {
+					nand = {
+						religion = ROOT
+						culture = ROOT
+					}
+					any_province_holding = {
+						not = { holding_type = nomad }
+					}
+					owner = {
+						same_realm = ROOT
+					}
+				}
+				religion = ROOT
+				culture = ROOT
+				set_province_flag = emf_nomad_settled
+				ROOT = {
+					change_variable = { which = n_convert value = -1 }
+					character_event = { id = emf_nomad.2 } # Recurse
+					break = yes # <-- Very important
+				}
+			}
+		}
 
-        # If we reach this point, we couldn't find any conversion targets next to
-        # already-settled provinces, so we should branch-out and find a new seed
-        # province from which to continue trying to cluster randomly.
+		# If we reach this point, we couldn't find any conversion targets next to
+		# already-settled provinces, so we should branch-out and find a new seed
+		# province from which to continue trying to cluster randomly.
 
-        # First, let's prefer new seeds that have the potential to grow to at least
-        # a 2-cluster (it's too easy to select a province with, say, just a temple
-        # in the middle of nomadic lands)
+		# First, let's prefer new seeds that have the potential to grow to at least
+		# a 2-cluster (it's too easy to select a province with, say, just a temple
+		# in the middle of nomadic lands)
 
-        random_realm_province = {
-            limit = {
-                nand = {
-                    religion = ROOT
-                    culture = ROOT
-                }
-                any_province_holding = {
-                    not = { holding_type = nomad }
-                }
-                any_neighbor_province = {
-                    nand = {
-                        religion = ROOT
-                        culture = ROOT
-                    }
-                    any_province_holding = {
-                        not = { holding_type = nomad }
-                    }
-                    owner = {
-                        or = {
-                            character = ROOT
-                            is_liege_or_above = ROOT
-                        }
-                    }
-                }
-            }
-            religion = ROOT
-            culture = ROOT
-            set_province_flag = emf_nomad_settled
-            ROOT = {
-                change_variable = { which = n_convert value = -1 }
-                character_event = { id = emf_nomad.2 } # Recurse
-                break = yes # <-- Very important
-            }
-        }
+		random_realm_province = {
+			limit = {
+				nand = {
+					religion = ROOT
+					culture = ROOT
+				}
+				any_province_holding = {
+					not = { holding_type = nomad }
+				}
+				any_neighbor_province = {
+					nand = {
+						religion = ROOT
+						culture = ROOT
+					}
+					any_province_holding = {
+						not = { holding_type = nomad }
+					}
+					owner = {
+						same_realm = ROOT
+					}
+				}
+			}
+			religion = ROOT
+			culture = ROOT
+			set_province_flag = emf_nomad_settled
+			ROOT = {
+				change_variable = { which = n_convert value = -1 }
+				character_event = { id = emf_nomad.2 } # Recurse
+				break = yes # <-- Very important
+			}
+		}
 
-        # If we reach this point, we first failed to grow the current cluster, then
-        # we failed to seed a province that had the potential to be a 2-cluster, so
-        # now we're just going to try converting any random non-nomadic province.
+		# If we reach this point, we first failed to grow the current cluster, then
+		# we failed to seed a province that had the potential to be a 2-cluster, so
+		# now we're just going to try converting any random non-nomadic province.
 
-        random_realm_province = {
-            limit = {
-                any_province_holding = {
-                    not = { holding_type = nomad }
-                }
-                nand = {
-                    religion = ROOT
-                    culture = ROOT
-                }
-            }
-            religion = ROOT
-            culture = ROOT
-            set_province_flag = emf_nomad_settled
-            ROOT = {
-                change_variable = { which = n_convert value = -1 }
-                character_event = { id = emf_nomad.2 } # Recurse
-            }
-        }
+		random_realm_province = {
+			limit = {
+				any_province_holding = {
+					not = { holding_type = nomad }
+				}
+				nand = {
+					religion = ROOT
+					culture = ROOT
+				}
+			}
+			religion = ROOT
+			culture = ROOT
+			set_province_flag = emf_nomad_settled
+			ROOT = {
+				change_variable = { which = n_convert value = -1 }
+				character_event = { id = emf_nomad.2 } # Recurse
+			}
+		}
 	}
 }
 
 
+# emf_nomad.3 [Settling Nomad]
+#
+# Invoked by nomad settlement decisions, prior to conversion to non-nomadic
+# government.
+#
+# Marks all nomadic demesne provinces so that the ones which are connected to the
+# new non-nomadic realm can be transferred back to the player after conversion to
+# a non-nomadic government. This is to override the hard-coded behavior which
+# transfers all nomadic provinces to the new Khagan of the remaining nomadic title.
 character_event = {
-    id = emf_nomad.3
-    hide_window = yes
-    is_triggered_only = yes
+	id = emf_nomad.3
+	hide_window = yes
+	is_triggered_only = yes
 
-    trigger = {
-        ai = no
-    }
+	trigger = {
+		ai = no
+	}
 
-    immediate = {
-        any_demesne_title = {
-            limit = {
-                tier = count
-                location = {
-                    not = {
-                        any_province_holding = {
-                            nor = {
-                                holding_type = nomad
-                                holding_type = temple
-                            }
-                        }
-                    }
-                }
-            }
-            set_title_flag = emf_nomad_demesne
-        }
-    }
+	immediate = {
+		any_demesne_title = {
+			limit = {
+				tier = count
+				location = {
+					not = {
+						any_province_holding = {
+							nor = {
+								holding_type = nomad
+								holding_type = temple
+							}
+						}
+					}
+				}
+			}
+			location = {
+				set_province_flag = emf_nomad_demesne
+			}
+		}
+	}
 }
 
 
+# emf_nomad.4 [Ex-Nomad]
+#
+# Completion event for emf_nomad.3 that actually transfers the ex-nomad's old
+# empty provinces, if they're connected to his new realm, back to him after he's
+# changed to a non-nomadic government.
 character_event = {
-    id = emf_nomad.4
-    hide_window = yes
-    is_triggered_only = yes
+	id = emf_nomad.4
+	hide_window = yes
+	is_triggered_only = yes
 
-    trigger = {
-        ai = no
-    }
+	trigger = {
+		ai = no
+	}
 
-    immediate = {
-        any_title = {
-            limit = {
-                tier = count
-                has_title_flag = emf_nomad_demesne
-            }
-            grant_title_no_opinion = ROOT
-            clr_title_flag = emf_nomad_demesne
-        }
-    }
+	immediate = {
+		# If the hard-code for some reason left us some nomadic provinces, then
+		# go ahead and remove them from this equation now.
+
+		any_realm_province = {
+			limit = {
+				has_province_flag = emf_nomad_demesne
+			}
+			clr_province_flag = emf_nomad_demesne
+		}
+
+		# Recursively reclaim realm-connected provinces ...
+
+		character_event = { id = emf_nomad.5 }
+
+		# Cleanup any flag state we've left behind (realm-unconnected nomadic
+		# provinces)...
+
+		any_title = {
+			limit = {
+				tier = count
+				location = {
+					has_province_flag = emf_nomad_demesne
+				}
+			}
+			location = {
+				clr_province_flag = emf_nomad_demesne
+			}
+		}
+	}
+}
+
+
+# emf_nomad.5 [Ex-Nomad]
+#
+# Guts of emf_nomad.4. Recurses upon realm provinces which border provinces
+# flagged as emf_nomad_demesne and reclaims them until there are no such
+# provinces left to reclaim.
+character_event = {
+	id = emf_nomad.5
+	hide_window = yes
+	is_triggered_only = yes
+
+	trigger = {
+		any_realm_province = {
+			any_neighbor_province = {
+				has_province_flag = emf_nomad_demesne
+			}
+		}
+	}
+
+	immediate = {
+		random_realm_province = {
+			limit = {
+				any_neighbor_province = {
+					has_province_flag = emf_nomad_demesne
+				}
+			}
+
+			any_neighbor_province = {
+				limit = {
+					has_province_flag = emf_nomad_demesne
+				}
+
+				county = {
+					grant_title_no_opinion = ROOT
+				}
+				clr_province_flag = emf_nomad_demesne
+			}
+		}
+
+		repeat_event = { id = emf_nomad.5 }
+	}
 }


### PR DESCRIPTION
Now, the only nomadic/empty provinces that will be retained by a nomad settling as feudal are ones that are directly-connected to the new, non-nomadic realm. This reduces a lot of potential border gore.