### PR TITLE
Fix for Baqt "infinite loop"

### DIFF
--- a/EMF/events/PB_startup_2.txt
+++ b/EMF/events/PB_startup_2.txt
@@ -7,12 +7,12 @@ narrative_event = { # NOTE: not currently an event that is ever shown to a playe
 	desc = AI_EVENT
 	hide_window = yes
 	is_triggered_only = yes
-	
+
 	immediate = {
 		# Dynamically setup worldwide Centers of Trade
 		# They also give an economic boost, but their primary purpose here is to influence
 		# technology spread, as the buildings are a direct source of tech points.
-		
+
 		b_dublin = { add_building = ct_trade_post_1 }
 		b_gandia = { add_building = ct_trade_post_1 }
 		b_newport = { add_building = ct_trade_post_1 }
@@ -304,11 +304,11 @@ narrative_event = { # NOTE: not currently an event that is ever shown to a playe
 			b_eivissa = { add_building = ct_trade_post_1 }
 			b_birka = { add_building = ct_trade_post_1 }
 			b_kaluga = { add_building = ct_trade_post_1 }
-			b_scarborough = { 
+			b_scarborough = {
 				add_building = ct_trade_post_1
 				add_building = ct_trade_post_2
 			}
-			b_gafsa = { 
+			b_gafsa = {
 				add_building = ct_trade_post_1
 				add_building = ct_trade_post_2
 			}
@@ -385,7 +385,7 @@ narrative_event = { # NOTE: not currently an event that is ever shown to a playe
 			}
 		}
 	}
-	
+
 	option = {
 		name = OK
 	}
@@ -398,22 +398,13 @@ narrative_event = {
 	desc = AI_EVENT
 	hide_window = yes
 	is_triggered_only = yes
-	
+
 	trigger = {
 		NOT = { has_global_flag = shattered_balance }
 	}
-	
+
 	option = {
 		name = OK
-		any_independent_ruler = {
-			limit = {
-				OR = {
-					culture_group = east_african
-					has_landed_title = k_shiite
-				}
-			}
-			narrative_event = { id = meneth.602 }
-		}
 	}
 }
 
@@ -421,15 +412,18 @@ narrative_event = {
 	id = meneth.602
 	title = meneth.601
 	desc = meneth.601.desc
-	
+
 	is_triggered_only = yes
 	hide_from = yes
-	
+
 	picture = GFX_evt_monk_muslim
-	
+
+	major = no
+
 	trigger = {
 		NOT = { has_global_flag = shattered_balance }
 	}
+
 	option = {
 		name = meneth.601.a
 		if = {

--- a/EMF/events/emf_startup.txt
+++ b/EMF/events/emf_startup.txt
@@ -87,6 +87,17 @@ character_event = {
 	option = {
 		name = OK
 
+		# Baqt Treaty
+		any_independent_ruler = {
+			limit = {
+				or = {
+					culture_group = east_african
+					has_landed_title = k_shiite
+				}
+			}
+			narrative_event = { id = meneth.602 }
+		}
+
 		narrative_event = { id = emf_startup.1 }
 	}
 }
@@ -108,10 +119,6 @@ narrative_event = {
 
 	option = {
 		name = emf_startup.1.opt.a
-
-		hidden_tooltip = {
-			FROM = { narrative_event = { id = meneth.601 } } # Baqt
-		}
 	}
 }
 


### PR DESCRIPTION
... not really a loop so much as excessive invocation.

I'm not really sure what changed in 2.4 to cause this, but it appears like it should've always happened (yet did not).