### PR TITLE
Probable solution to event troop ghost armies

### DIFF
--- a/EMF/events/rebel_events_the_old_gods.txt
+++ b/EMF/events/rebel_events_the_old_gods.txt
@@ -1,0 +1,3071 @@
+#########################################################
+#
+# Rebel Events for The Old Gods DLC
+# ( TOG.1000 to TOG.1199)
+#
+# NOTE: The Old Gods DLC disables the old rebel system
+#
+#########################################################
+
+# Written by Henrik Fåhraeus
+
+namespace = TOG
+
+# Peasant Rebels rise up (temporary rebel title created, with a leader and a war)
+# Triggered from "on_rebel_revolt"
+province_event = {
+	id = TOG.1000
+	desc = EVTDESC_TOG_1000
+	picture = GFX_evt_peasants
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+
+	trigger = {
+		has_dlc = "The Old Gods"
+		
+		# Will get clan rebels instead
+		NAND = {
+			has_empty_holding = yes
+			owner = {
+				is_nomadic = yes
+			}
+		}
+		
+		any_province_holding = {
+			NOT = { holding_type = nomad }
+		}
+		
+		# Heretic revolts have prio
+		OR = {
+			is_heretic = no
+			owner = {
+				top_liege = {
+					NOT = { is_parent_religion = ROOT }
+				}
+			}
+		}
+		
+		# Religious revolts have prio
+		owner = {
+			top_liege = {
+				religion_group = ROOT
+			}
+		}
+		
+		# Nationalist revolts have prio
+		OR = {
+			owner = {
+				top_liege = {
+					culture = ROOT
+				}
+			}
+			kingdom = {
+				OR = {
+					has_holder = yes
+					NOT = { culture = ROOT }
+				}
+			}
+		}
+		
+		NOT = { # Not if there is already an ongoing peasant revolt for this province
+			owner = {
+				top_liege = {
+					war = yes
+					
+					any_war = {
+						defender = { character = PREV }
+						OR = {
+							AND = {
+								using_cb = peasant_revolt
+								war_title = ROOT # The county
+							}
+							AND = {
+								using_cb = heretic_revolt
+								attacker = { religion = ROOT }
+							}
+							AND = {
+								using_cb = religious_revolt
+								attacker = { religion = ROOT }
+							}
+							AND = {
+								using_cb = liberation_revolt
+								thirdparty_title_scope = {
+									ROOT = {
+										kingdom = {
+											title = PREVPREV
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	immediate = {
+		create_character = {
+			random_traits = yes
+			dynasty = none
+			religion = ROOT
+			culture = ROOT
+			female = no
+			age = 25
+			attributes = {
+				martial = 5
+			}
+			trait = peasant_leader
+			trait = tough_soldier
+		}
+		
+		new_character = {
+			create_title = {
+				tier = DUKE
+				landless = yes
+				temporary = yes
+				rebel = yes
+				culture = ROOT
+				name = "PEASANT_REVOLT"
+				holder = THIS
+			}
+			
+			wealth = 100
+			
+			random_list = {
+				17 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_by_biggest_garrison = 0.75
+						troops = {
+							archers = { 6 6 }
+							light_cavalry = { 4 4 }
+							light_infantry = { 10 10 }
+						}
+						attrition = 1.0
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 0.75
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 4 4 }
+								light_infantry = { 10 10 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 31
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 0.75
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 4 4 }
+								light_infantry = { 10 10 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+				}
+				17 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_by_biggest_garrison = 0.5
+						troops = {
+							archers = { 6 6 }
+							light_cavalry = { 4 4 }
+							light_infantry = { 10 10 }
+						}
+						attrition = 1.0
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 0.5
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 4 4 }
+								light_infantry = { 10 10 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 31
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 0.5
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 4 4 }
+								light_infantry = { 10 10 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+				}
+				16 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_by_biggest_garrison = 0.75
+						troops = {
+							archers = { 6 6 }
+							light_cavalry = { 3 3 }
+							light_infantry = { 11 11 }
+						}
+						attrition = 1.0
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 0.75
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 3 3 }
+								light_infantry = { 11 11 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 31
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 0.75
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 3 3 }
+								light_infantry = { 11 11 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+				}
+				17 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_by_biggest_garrison = 0.5
+						troops = {
+							archers = { 6 6 }
+							light_cavalry = { 3 3 }
+							light_infantry = { 11 11 }
+						}
+						attrition = 1.0
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 0.5
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 3 3 }
+								light_infantry = { 11 11 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 31
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 0.5
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 3 3 }
+								light_infantry = { 11 11 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+				}
+				16 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_by_biggest_garrison = 0.75
+						troops = {
+							archers = { 6 6 }
+							light_infantry = { 14 14 }
+						}
+						attrition = 1.0
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 0.75
+							troops = {
+								archers = { 6 6 }
+								light_infantry = { 14 14 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 31
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 0.75
+							troops = {
+								archers = { 6 6 }
+								light_infantry = { 14 14 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+				}
+				17 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_by_biggest_garrison = 0.5
+						troops = {
+							archers = { 6 6 }
+							light_infantry = { 14 14 }
+						}
+						attrition = 1.0
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 0.5
+							troops = {
+								archers = { 6 6 }
+								light_infantry = { 14 14 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 31
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 0.5
+							troops = {
+								archers = { 6 6 }
+								light_infantry = { 14 14 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+				}
+			}
+			
+			# DoW on the province top liege
+			ROOT = {
+				owner = {
+					top_liege = {
+#						set_defacto_vassal = PREVPREVPREV
+						reverse_war = {
+							target = PREVPREVPREV
+							casus_belli = peasant_revolt
+							thirdparty_title = ROOT # The county
+						}
+						reverse_opinion = {
+							who = PREVPREVPREV
+							modifier = opinion_evil_tyrant
+						}
+					}
+				}
+			}
+		}
+		
+		owner = {
+			any_liege = { # Inform the lieges
+				character_event = {
+					id = TOG.1001
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = "EVTOPTA_TOG_1000"
+	}
+}
+
+character_event = {
+	id = TOG.1001
+	desc = EVTDESC_TOG_1001
+	picture = GFX_evt_peasants
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVTOPTA_TOG_1000"
+	}
+}
+
+# Peasants seize a holding. Fired from 'on_siege_over_winner'.
+character_event = {
+	id = TOG.1005
+	picture = GFX_evt_siege
+	
+	hide_window = yes
+	is_triggered_only = yes
+	
+	desc = OK
+	
+	trigger = {
+		trait = peasant_leader
+		rebel = yes
+		FROM = { 
+			is_capital = yes # The capital holding
+		}
+	}
+	
+	immediate = {
+		FROM = {
+			location = {
+				if = {
+					limit = {
+						NOT = { has_province_modifier = peasant_unrest }
+					}
+					add_province_modifier = {
+						name = peasant_unrest
+						duration = 730
+					}
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = OK
+	}
+}
+
+# Peasant Rebels rise up to reinforce an ongoing provincial peasant revolt
+# Triggered from "on_rebel_revolt"
+province_event = {
+	id = TOG.1010
+	desc = EVTDESC_TOG_1010
+	picture = GFX_evt_peasants
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+
+	trigger = {
+		has_dlc = "The Old Gods"
+		
+		any_province_holding = {
+			NOT = { holding_type = nomad }
+		}
+
+		# There is already an ongoing peasant revolt for this province
+		owner = {
+			top_liege = {
+				war = yes
+				any_war = {
+					defender = { character = PREV }
+					using_cb = peasant_revolt
+					war_title = ROOT # The county
+				}
+			}
+		}
+	}
+	
+	immediate = {
+		
+		add_province_modifier = {
+			name = recent_county_uprising
+			duration = 1825 # Five years of -100% revolt risk in this county
+		}
+		
+		owner = {
+			top_liege = {
+				any_war = {
+					limit = {
+						defender = { character = PREV }
+						using_cb = peasant_revolt
+						war_title = ROOT # The county
+					}
+					attacker = {
+						random_list = {
+							17 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.75
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 4 4 }
+											light_infantry = { 10 10 }
+										}
+										attrition = 1.0
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.75
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 4 4 }
+											light_infantry = { 10 10 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 31
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.75
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 4 4 }
+											light_infantry = { 10 10 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+							}
+							17 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.5
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 4 4 }
+											light_infantry = { 10 10 }
+										}
+										attrition = 1.0
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.5
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 4 4 }
+											light_infantry = { 10 10 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 31
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.5
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 4 4 }
+											light_infantry = { 10 10 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+							}
+							16 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.75
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 3 3 }
+											light_infantry = { 11 11 }
+										}
+										attrition = 1.0
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.75
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 3 3 }
+											light_infantry = { 11 11 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 31
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.75
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 3 3 }
+											light_infantry = { 11 11 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+							}
+							17 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.5
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 3 3 }
+											light_infantry = { 11 11 }
+										}
+										attrition = 1.0
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.5
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 3 3 }
+											light_infantry = { 11 11 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 31
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.5
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 3 3 }
+											light_infantry = { 11 11 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+							}
+							16 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.75
+										troops = {
+											archers = { 6 6 }
+											light_infantry = { 14 14 }
+										}
+										attrition = 1.0
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.75
+										troops = {
+											archers = { 6 6 }
+											light_infantry = { 14 14 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 31
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.75
+										troops = {
+											archers = { 6 6 }
+											light_infantry = { 14 14 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+							}
+							17 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.5
+										troops = {
+											archers = { 6 6 }
+											light_infantry = { 14 14 }
+										}
+										attrition = 1.0
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.5
+										troops = {
+											archers = { 6 6 }
+											light_infantry = { 14 14 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 31
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 0.5
+										troops = {
+											archers = { 6 6 }
+											light_infantry = { 14 14 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		owner = {
+			any_liege = { # Inform the lieges
+				character_event = {
+					id = TOG.1011
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = "EVTOPTA_TOG_1010"
+	}
+}
+
+character_event = {
+	id = TOG.1011
+	desc = EVTDESC_TOG_1011
+	picture = GFX_evt_peasants
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVTOPTA_TOG_1010"
+	}
+}
+
+# Heretic Rebels rise up (temporary rebel title created, with a leader and a war)
+# Triggered from "on_rebel_revolt"
+province_event = {
+	id = TOG.1020
+	desc = EVTDESC_TOG_1020
+	picture = GFX_evt_heretic
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+
+	trigger = {
+		has_dlc = "The Old Gods"
+		
+		is_heretic = yes
+		
+		any_province_holding = {
+			NOT = { holding_type = nomad }
+		}
+
+		owner = {
+			top_liege = {
+				is_parent_religion = ROOT
+			}
+		}
+		
+		NOT = { # Not if there is already an ongoing revolt
+			owner = {
+				top_liege = {
+					war = yes
+					any_war = {
+						defender = { character = PREV }
+						OR = {
+							AND = {
+								using_cb = peasant_revolt
+								war_title = ROOT # The county
+							}
+							AND = {
+								using_cb = heretic_revolt
+								attacker = { religion = ROOT }
+							}
+							AND = {
+								using_cb = religious_revolt
+								attacker = { religion = ROOT }
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	immediate = {
+		create_character = {
+			random_traits = yes
+			dynasty = none
+			religion = ROOT
+			culture = ROOT
+			female = no
+			age = 32
+			attributes = {
+				martial = 7
+				learning = 7
+			}
+			trait = heresiarch
+			trait = zealous
+			trait = scholar
+			trait = skilled_tactician
+		}
+		
+		new_character = {
+			set_character_flag = heretic_revolter
+			
+			create_title = {
+				tier = DUKE
+				landless = yes
+				temporary = yes
+				rebel = yes
+				culture = ROOT
+				name = "HERETIC_REVOLT"
+				holder = THIS
+			}
+			
+			wealth = 100
+			
+			random_list = {
+				34 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_by_biggest_garrison = 1.0
+						troops = {
+							archers = { 6 6 }
+							light_cavalry = { 4 4 }
+							light_infantry = { 10 10 }
+						}
+						attrition = 1.0
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 1.0
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 4 4 }
+								light_infantry = { 10 10 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 23
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 1.0
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 4 4 }
+								light_infantry = { 10 10 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+				}
+				33 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_by_biggest_garrison = 1.0
+						troops = {
+							archers = { 6 6 }
+							light_cavalry = { 2 2 }
+							light_infantry = { 12 12 }
+						}
+						attrition = 1.0
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 1.0
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 2 2 }
+								light_infantry = { 12 12 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 23
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 1.0
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 2 2 }
+								light_infantry = { 12 12 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+				}
+				33 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_by_biggest_garrison = 1.0
+						troops = {
+							archers = { 6 6 }
+							light_infantry = { 14 14 }
+						}
+						attrition = 1.0
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 1.0
+							troops = {
+								archers = { 6 6 }
+								light_infantry = { 14 14 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 23
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 1.0
+							troops = {
+								archers = { 6 6 }
+								light_infantry = { 14 14 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+				}
+			}
+			
+			# DoW on the province top liege
+			ROOT = {
+				owner = {
+					top_liege = {
+						reverse_war = {
+							target = PREVPREVPREV
+							casus_belli = heretic_revolt
+						}
+						reverse_opinion = {
+							who = PREVPREVPREV
+							modifier = opinion_evil_tyrant
+						}
+					}
+				}
+			}
+		}
+		
+		owner = {
+			any_liege = { # Inform the lieges
+				character_event = {
+					id = TOG.1021
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = "EVTOPTA_TOG_1020"
+	}
+}
+
+character_event = {
+	id = TOG.1021
+	desc = EVTDESC_TOG_1021
+	picture = GFX_evt_heretic
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_TOG_1020
+	}
+}
+
+# Heretics seize a holding. Fired from 'on_siege_over_winner'.
+character_event = {
+	id = TOG.1025
+	picture = GFX_evt_siege
+	
+	hide_window = yes
+	is_triggered_only = yes
+	
+	desc = OK
+	
+	trigger = {
+		trait = heresiarch
+		rebel = yes
+		FROM = { 
+			is_capital = yes # The capital holding
+		}
+	}
+	
+	immediate = {
+		FROM = {
+			location = {
+				if = {
+					limit = {
+						NOT = { religion = ROOT }
+					}
+					random = {
+						chance = 50
+						religion = ROOT
+					}
+				}
+				if = {
+					limit = {
+						NOT = { has_province_modifier = religious_unrest }
+					}
+					add_province_modifier = {
+						name = religious_unrest
+						duration = 730
+					}
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = OK
+	}
+}
+
+# Heretic Rebels rise up to reinforce an ongoing heretic uprising
+# Triggered from "on_rebel_revolt"
+province_event = {
+	id = TOG.1030
+	desc = EVTDESC_TOG_1030
+	picture = GFX_evt_heretic
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+
+	trigger = {
+		has_dlc = "The Old Gods"
+		
+		is_heretic = yes
+		
+		owner = {
+			top_liege = {
+				is_parent_religion = ROOT
+			}
+		}
+		
+		any_province_holding = {
+			NOT = { holding_type = nomad }
+		}
+
+		owner = {
+			top_liege = {
+				war = yes
+				any_war = {
+					defender = { character = PREV }
+					using_cb = heretic_revolt
+					attacker = { religion = ROOT }
+				}
+			}
+		}
+	}
+	
+	immediate = {
+	
+		add_province_modifier = {
+			name = recent_county_uprising
+			duration = 1825 # Five years of -100% revolt risk in this county
+		}
+	
+		owner = {
+			top_liege = {
+				any_war = {
+					limit = {
+						defender = { character = PREV }
+						using_cb = heretic_revolt
+						attacker = { religion = ROOT }
+					}
+					attacker = {
+						random_list = {
+							34 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 4 4 }
+											light_infantry = { 10 10 }
+										}
+										attrition = 1.0
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 4 4 }
+											light_infantry = { 10 10 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 23
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 4 4 }
+											light_infantry = { 10 10 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+							}
+							33 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 2 2 }
+											light_infantry = { 12 12 }
+										}
+										attrition = 1.0
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 2 2 }
+											light_infantry = { 12 12 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 23
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 2 2 }
+											light_infantry = { 12 12 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+							}
+							33 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_infantry = { 14 14 }
+										}
+										attrition = 1.0
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_infantry = { 14 14 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 23
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_infantry = { 14 14 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		owner = {
+			any_liege = { # Inform the lieges
+				character_event = {
+					id = TOG.1031
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = "EVTOPTA_TOG_1030"
+	}
+}
+
+character_event = {
+	id = TOG.1031
+	desc = EVTDESC_TOG_1031
+	picture = GFX_evt_heretic
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVTOPTA_TOG_1030"
+	}
+}
+
+# Royalist Nationalist Rebels rise up to create a kingdom (temporary rebel title created, with a leader and a war)
+# Triggered from "on_rebel_revolt"
+province_event = {
+	id = TOG.1040
+	desc = EVTDESC_TOG_1040
+	picture = GFX_evt_siege
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+
+	trigger = {
+		has_dlc = "The Old Gods"
+
+		any_province_holding = {
+			NOT = { holding_type = nomad }
+		}
+		
+		owner = {
+			top_liege = {
+				NOT = { culture = ROOT }
+			}
+		}
+		
+		kingdom = {
+			has_holder = no
+			culture = ROOT
+			
+			# The de jure kingdom must have had an appropriate holder in the past
+			any_previous_holder = {
+				ROOT = {
+					owner = {
+						top_liege = {
+							NOT = { dynasty = PREVPREVPREV }
+							OR = {
+								is_nomadic = no
+								NOT = { culture_group = ROOT }
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		# Heretic revolts have prio
+		OR = { 
+			is_heretic = no
+			owner = {
+				top_liege = {
+					NOT = { is_parent_religion = ROOT }
+				}
+			}
+		}
+		
+		NOT = { # Not if there is already an ongoing revolt
+			owner = {
+				top_liege = {
+					war = yes
+					any_war = {
+						defender = { character = PREV }
+						OR = {
+							AND = {
+								using_cb = heretic_revolt
+								attacker = { religion = ROOT }
+							}
+							AND = {
+								using_cb = liberation_revolt
+								thirdparty_title_scope = {
+									ROOT = {
+										kingdom = {
+											title = PREVPREV
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	immediate = {
+		create_character = {
+			random_traits = yes
+			dynasty = random
+			religion = ROOT
+			culture = ROOT
+			female = no
+			age = 20
+			health = 7
+			fertility = 0.7
+			attributes = {
+				martial = 8
+				diplomacy = 9
+			}
+			trait = just
+			trait = brave
+			trait = gregarious
+			trait = ambitious
+			trait = brilliant_strategist
+			trait = inspiring_leader
+		}
+		
+		new_character = {
+			set_character_flag = nationalist_rebel
+			
+			create_title = {
+				tier = DUKE
+				landless = yes
+				temporary = yes
+				rebel = yes
+				culture = ROOT
+				name = "NATIONALIST_REVOLT"
+				holder = THIS
+			}
+			
+			wealth = 100
+			
+			spawn_unit = {
+				province = ROOT
+				home = ROOT
+				owner = THIS
+				#leader = THIS
+				scaled_by_biggest_garrison = 1.75
+				troops = {
+					archers = { 6 6 }
+					light_cavalry = { 3 3 }
+					knights = { 1 1 }
+					light_infantry = { 7 7 }
+					heavy_infantry = { 3 3 }
+				}
+				attrition = 1.0
+			}
+			
+			create_character = {
+				random_traits = yes
+				dynasty = none
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 34
+				attributes = {
+					martial = 7
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				spawn_unit = {
+					province = ROOT
+					home = ROOT
+					owner = PREV
+					#leader = THIS
+					scaled_by_biggest_garrison = 1.75
+					troops = {
+						archers = { 6 6 }
+						light_cavalry = { 3 3 }
+						knights = { 1 1 }
+						light_infantry = { 7 7 }
+						heavy_infantry = { 3 3 }
+					}
+				}
+			}
+			
+			create_character = {
+				random_traits = yes
+				dynasty = none
+				religion = ROOT
+				culture = ROOT
+				female = no
+				age = 23
+				attributes = {
+					martial = 7
+				}
+				trait = skilled_tactician
+			}
+			new_character = {
+				spawn_unit = {
+					province = ROOT
+					home = ROOT
+					owner = PREV
+					#leader = THIS
+					scaled_by_biggest_garrison = 1.75
+					troops = {
+						archers = { 6 6 }
+						light_cavalry = { 3 3 }
+						knights = { 1 1 }
+						light_infantry = { 7 7 }
+						heavy_infantry = { 3 3 }
+					}
+				}
+			}
+			
+			# DoW on the province top liege
+			ROOT = {
+				owner = {
+					top_liege = {
+						reverse_war = {
+							target = PREVPREVPREV
+							casus_belli = liberation_revolt
+							thirdparty_title = ROOT # The county...
+							tier = KING # ... but really the de jure kingdom
+						}
+						reverse_opinion = {
+							who = PREVPREVPREV
+							modifier = opinion_evil_tyrant
+						}
+					}
+				}
+			}
+		}
+		
+		owner = {
+			any_liege = { # Inform the lieges
+				character_event = {
+					id = TOG.1041
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = "EVTOPTA_TOG_1040"
+	}
+}
+
+character_event = {
+	id = TOG.1041
+	desc = EVTDESC_TOG_1041
+	picture = GFX_evt_siege
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_TOG_1040
+	}
+}
+
+# Nationalists seize a holding. Fired from 'on_siege_over_winner'.
+character_event = {
+	id = TOG.1045
+	picture = GFX_evt_siege
+	
+	hide_window = yes
+	is_triggered_only = yes
+	
+	desc = OK
+	
+	trigger = {
+		rebel = yes
+		FROM = { 
+			is_capital = yes # The capital holding
+		}
+		any_war = {
+			attacker = { character = ROOT }
+			using_cb = liberation_revolt
+		}
+	}
+	
+	immediate = {
+		FROM = {
+			location = {
+				if = {
+					limit = {
+						NOT = { culture = ROOT }
+						kingdom = { culture = ROOT }
+					}
+					random = {
+						chance = 20
+						culture = ROOT
+					}
+				}
+				if = {
+					limit = {
+						culture = ROOT
+						NOT = { has_province_modifier = cultural_unrest }
+					}
+					add_province_modifier = {
+						name = cultural_unrest
+						duration = 730
+					}
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = OK
+	}
+}
+
+# Nationalist Rebels rise up to reinforce an ongoing revolt
+# Triggered from "on_rebel_revolt"
+province_event = {
+	id = TOG.1050
+	desc = EVTDESC_TOG_1050
+	picture = GFX_evt_siege
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+
+	trigger = {
+		has_dlc = "The Old Gods"
+
+		any_province_holding = {
+			NOT = { holding_type = nomad }
+		}
+		
+		# There is already an ongoing nationalist revolt for the same kingdom
+		owner = {
+			top_liege = {
+				war = yes
+				any_war = {
+					defender = { character = PREV }
+					using_cb = liberation_revolt
+					thirdparty_title_scope = {
+						ROOT = {
+							kingdom = {
+								title = PREVPREV
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	immediate = {
+		owner = {
+			top_liege = {
+				any_war = {
+					limit = {
+						defender = { character = PREV }
+						using_cb = liberation_revolt
+						thirdparty_title_scope = {
+							ROOT = {
+								kingdom = {
+									title = PREVPREV
+								}
+							}
+						}
+					}
+					attacker = {
+						create_character = {
+							random_traits = yes
+							dynasty = none
+							religion = ROOT
+							culture = ROOT
+							female = no
+							age = 24
+							attributes = {
+								martial = 7
+							}
+							trait = skilled_tactician
+						}
+						new_character = {
+							spawn_unit = {
+								province = ROOT
+								home = ROOT
+								owner = PREV
+								#leader = THIS
+								scaled_by_biggest_garrison = 1.75
+								troops = {
+									archers = { 6 6 }
+									light_cavalry = { 3 3 }
+									knights = { 1 1 }
+									light_infantry = { 7 7 }
+									heavy_infantry = { 3 3 }
+								}
+							}
+						}
+						create_character = {
+							random_traits = yes
+							dynasty = none
+							religion = ROOT
+							culture = ROOT
+							female = no
+							age = 27
+							attributes = {
+								martial = 7
+							}
+							trait = skilled_tactician
+						}
+						new_character = {
+							spawn_unit = {
+								province = ROOT
+								home = ROOT
+								owner = PREV
+								#leader = THIS
+								scaled_by_biggest_garrison = 1.75
+								troops = {
+									archers = { 6 6 }
+									light_cavalry = { 3 3 }
+									knights = { 1 1 }
+									light_infantry = { 7 7 }
+									heavy_infantry = { 3 3 }
+								}
+							}
+						}
+						create_character = {
+							random_traits = yes
+							dynasty = none
+							religion = ROOT
+							culture = ROOT
+							female = no
+							age = 30
+							attributes = {
+								martial = 7
+							}
+							trait = skilled_tactician
+						}
+						new_character = {
+							spawn_unit = {
+								province = ROOT
+								home = ROOT
+								owner = PREV
+								#leader = THIS
+								scaled_by_biggest_garrison = 1.75
+								troops = {
+									archers = { 6 6 }
+									light_cavalry = { 3 3 }
+									knights = { 1 1 }
+									light_infantry = { 7 7 }
+									heavy_infantry = { 3 3 }
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		owner = {
+			any_liege = { # Inform the lieges
+				character_event = {
+					id = TOG.1051
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = "EVTOPTA_TOG_1000"
+	}
+}
+
+character_event = {
+	id = TOG.1051
+	desc = EVTDESC_TOG_1051
+	picture = GFX_evt_siege
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_TOG_1000
+	}
+}
+
+# Religious Rebels rise up (temporary rebel title created, with a leader and a war)
+# Triggered from "on_rebel_revolt"
+province_event = {
+	id = TOG.1060
+	desc = EVTDESC_TOG_1060
+	picture = GFX_evt_heretic
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+
+	trigger = {
+		has_dlc = "The Old Gods"
+		
+		is_heretic = no
+
+		any_province_holding = {
+			NOT = { holding_type = nomad }
+		}
+		
+		owner = {
+			top_liege = {
+				NOT = { religion_group = ROOT }
+			}
+		}
+		
+		# Nationalist revolts have prio
+		OR = {
+			owner = {
+				top_liege = {
+					culture = ROOT
+				}
+			}
+			kingdom = {
+				OR = {
+					has_holder = yes
+					NOT = { culture = ROOT }
+				}
+			}
+		}
+		
+		NOT = { # Not if there is already an ongoing revolt
+			owner = {
+				top_liege = {
+					war = yes
+					any_war = {
+						defender = { character = PREV }
+						OR = {
+							AND = {
+								using_cb = peasant_revolt
+								war_title = ROOT # The county
+							}
+							AND = {
+								using_cb = heretic_revolt
+								attacker = { religion = ROOT }
+							}
+							AND = {
+								using_cb = religious_revolt
+								attacker = { religion = ROOT }
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	immediate = {
+		create_character = {
+			random_traits = yes
+			dynasty = none
+			religion = ROOT
+			culture = ROOT
+			female = no
+			age = 32
+			attributes = {
+				martial = 7
+				learning = 7
+			}
+			trait = zealous
+			trait = scholar
+			trait = skilled_tactician
+		}
+		
+		new_character = {
+			set_character_flag = religious_revolter
+			
+			create_title = {
+				tier = DUKE
+				landless = yes
+				temporary = yes
+				rebel = yes
+				culture = ROOT
+				name = "HERETIC_REVOLT"
+				holder = THIS
+			}
+			
+			wealth = 100
+			
+			random_list = {
+				34 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_by_biggest_garrison = 1.0
+						troops = {
+							archers = { 6 6 }
+							light_cavalry = { 4 4 }
+							light_infantry = { 10 10 }
+						}
+						attrition = 1.0
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 1.0
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 4 4 }
+								light_infantry = { 10 10 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 23
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 1.0
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 4 4 }
+								light_infantry = { 10 10 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+				}
+				33 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_by_biggest_garrison = 1.0
+						troops = {
+							archers = { 6 6 }
+							light_cavalry = { 2 2 }
+							light_infantry = { 12 12 }
+						}
+						attrition = 1.0
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 1.0
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 2 2 }
+								light_infantry = { 12 12 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 23
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 1.0
+							troops = {
+								archers = { 6 6 }
+								light_cavalry = { 2 2 }
+								light_infantry = { 12 12 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+				}
+				33 = {
+					spawn_unit = {
+						province = ROOT
+						home = ROOT
+						owner = THIS
+						#leader = THIS
+						scaled_by_biggest_garrison = 1.0
+						troops = {
+							archers = { 6 6 }
+							light_infantry = { 14 14 }
+						}
+						attrition = 1.0
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 30
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 1.0
+							troops = {
+								archers = { 6 6 }
+								light_infantry = { 14 14 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+					create_character = {
+						random_traits = yes
+						dynasty = none
+						religion = THIS
+						culture = THIS
+						female = no
+						age = 23
+						trait = peasant_leader
+						trait = tough_soldier
+					}
+					new_character = {
+						spawn_unit = {
+							province = ROOT
+							home = ROOT
+							owner = PREV
+							scaled_by_biggest_garrison = 1.0
+							troops = {
+								archers = { 6 6 }
+								light_infantry = { 14 14 }
+							}
+							attrition = 1.0
+							disband_on_peace = yes
+						}
+					}
+				}
+			}
+			
+			# DoW on the province top liege
+			ROOT = {
+				owner = {
+					top_liege = {
+						reverse_war = {
+							target = PREVPREVPREV
+							casus_belli = religious_revolt
+						}
+						reverse_opinion = {
+							who = PREVPREVPREV
+							modifier = opinion_evil_tyrant
+						}
+					}
+				}
+			}
+		}
+		
+		owner = {
+			any_liege = { # Inform the lieges
+				character_event = {
+					id = TOG.1061
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = EVTOPTA_TOG_1060
+		trigger = {
+			owner = { religion_group = ROOT }
+		}
+	}
+	option = {
+		name = EVTOPTB_TOG_1060
+		trigger = {
+			owner = { NOT = { religion_group = ROOT	} }
+		}
+	}
+}
+
+character_event = {
+	id = TOG.1061
+	desc = EVTDESC_TOG_1061
+	picture = GFX_evt_heretic
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_TOG_1060
+		trigger = {
+			owner = { religion_group = FROM }
+		}
+	}
+	option = {
+		name = EVTOPTB_TOG_1060
+		trigger = {
+			owner = { NOT = { religion_group = FROM	} }
+		}
+	}
+}
+
+# Religious Rebels seize a holding. Fired from 'on_siege_over_winner'. Owner of the winning unit is ROOT. The taken Holding title is in FROM.
+character_event = {
+	id = TOG.1065
+	picture = GFX_evt_siege
+	
+	hide_window = yes
+	is_triggered_only = yes
+	
+	desc = OK
+	
+	trigger = {
+		has_character_flag = religious_revolter
+		rebel = yes
+		FROM = { 
+			is_capital = yes # The capital holding
+		}
+	}
+	
+	immediate = {
+		FROM = {
+			location = {
+				if = {
+					limit = {
+						NOT = { religion = ROOT }
+					}
+					random = {
+						chance = 5
+						religion = ROOT
+					}
+				}
+				if = {
+					limit = {
+						NOT = { has_province_modifier = religious_unrest }
+					}
+					add_province_modifier = {
+						name = religious_unrest
+						duration = 730
+					}
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = OK
+	}
+}
+
+# Religious Rebels rise up to reinforce an ongoing religious uprising
+# Triggered from "on_rebel_revolt"
+province_event = {
+	id = TOG.1070
+	desc = EVTDESC_TOG_1070
+	picture = GFX_evt_heretic
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+
+	trigger = {
+		has_dlc = "The Old Gods"
+		
+		is_heretic = no
+
+		any_province_holding = {
+			NOT = { holding_type = nomad }
+		}
+		
+		owner = {
+			top_liege = {
+				NOT = { religion_group = ROOT }
+			}
+		}
+		
+		owner = {
+			top_liege = {
+				war = yes
+				any_war = {
+					defender = { character = PREV }
+					using_cb = religious_revolt
+					attacker = { religion = ROOT }
+				}
+			}
+		}
+	}
+	
+	immediate = {
+	
+		add_province_modifier = {
+			name = recent_county_uprising
+			duration = 1825 # Five years of -100% revolt risk in this county
+		}
+	
+		owner = {
+			top_liege = {
+				any_war = {
+					limit = {
+						defender = { character = PREV }
+						using_cb = religious_revolt
+						attacker = { religion = ROOT }
+					}
+					attacker = {
+						random_list = {
+							34 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 4 4 }
+											light_infantry = { 10 10 }
+										}
+										attrition = 1.0
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 4 4 }
+											light_infantry = { 10 10 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 23
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 4 4 }
+											light_infantry = { 10 10 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+							}
+							33 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 2 2 }
+											light_infantry = { 12 12 }
+										}
+										attrition = 1.0
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 2 2 }
+											light_infantry = { 12 12 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 23
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_cavalry = { 2 2 }
+											light_infantry = { 12 12 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+							}
+							33 = {
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 25
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_infantry = { 14 14 }
+										}
+										attrition = 1.0
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 30
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_infantry = { 14 14 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+								create_character = {
+									random_traits = yes
+									dynasty = none
+									religion = THIS
+									culture = THIS
+									female = no
+									age = 23
+									trait = peasant_leader
+									trait = tough_soldier
+								}
+								new_character = {
+									spawn_unit = {
+										province = ROOT
+										home = ROOT
+										owner = PREV
+										scaled_by_biggest_garrison = 1.0
+										troops = {
+											archers = { 6 6 }
+											light_infantry = { 14 14 }
+										}
+										attrition = 1.0
+										disband_on_peace = yes
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		owner = {
+			any_liege = { # Inform the lieges
+				character_event = {
+					id = TOG.1071
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = "EVTOPTA_TOG_1070"
+	}
+}
+
+character_event = {
+	id = TOG.1071
+	desc = EVTDESC_TOG_1071
+	picture = GFX_evt_heretic
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVTOPTA_TOG_1070"
+	}
+}
+
+# Rebels kill a local character. Fired from 'on_siege_over_loc_chars'.
+# Siege winner unit owner in the 'new_character' scope, lost holding title in FROM, local character in ROOT.
+character_event = {
+	id = TOG.1190
+	desc = EVTDESC_TOG_1190
+	picture = GFX_evt_beheading
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	trigger = {
+		new_character = {
+			rebel = yes
+			
+			OR = {
+				NOT = { religion = ROOT }
+				AND = {
+					NOT = { has_character_flag = heretic_revolter }
+					NOT = { has_character_flag = religious_revolter }
+					NOT = { has_character_flag = shepherds_crusade_leader }
+				}
+			}
+		}
+	}
+	
+	weight_multiplier = {
+		days = 1
+		modifier = {
+			factor = 0.5
+			is_female = yes
+		}
+		modifier = {
+			factor = 0.5
+			is_adult = no
+		}
+	}
+	
+	immediate = {
+		any_liege = { # Inform the victim's lieges
+			character_event = {
+				id = TOG.1191
+			}
+		}
+		new_character = {
+			ROOT = {
+				death = {
+					death_reason = death_rabble
+					killer = PREV
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = EVTOPTA_TOG_1190
+	}
+}
+
+
+# Lieges informed
+character_event = {
+	id = TOG.1191
+	picture = GFX_evt_beheading
+	desc = EVTDESC_TOG_1191
+	border = GFX_event_normal_frame_war
+	
+	is_triggered_only = yes
+	
+	notification = yes
+	
+	ai = no
+	
+	option = {
+		name = EVTOPTA_TOG_1191
+	}
+}
+

--- a/EMF/events/rebel_events_the_old_gods.txt
+++ b/EMF/events/rebel_events_the_old_gods.txt
@@ -18,12 +18,12 @@ province_event = {
 	desc = EVTDESC_TOG_1000
 	picture = GFX_evt_peasants
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
 
 	trigger = {
 		has_dlc = "The Old Gods"
-		
+
 		# Will get clan rebels instead
 		NAND = {
 			has_empty_holding = yes
@@ -31,11 +31,11 @@ province_event = {
 				is_nomadic = yes
 			}
 		}
-		
+
 		any_province_holding = {
 			NOT = { holding_type = nomad }
 		}
-		
+
 		# Heretic revolts have prio
 		OR = {
 			is_heretic = no
@@ -45,14 +45,14 @@ province_event = {
 				}
 			}
 		}
-		
+
 		# Religious revolts have prio
 		owner = {
 			top_liege = {
 				religion_group = ROOT
 			}
 		}
-		
+
 		# Nationalist revolts have prio
 		OR = {
 			owner = {
@@ -67,12 +67,12 @@ province_event = {
 				}
 			}
 		}
-		
+
 		NOT = { # Not if there is already an ongoing peasant revolt for this province
 			owner = {
 				top_liege = {
 					war = yes
-					
+
 					any_war = {
 						defender = { character = PREV }
 						OR = {
@@ -104,7 +104,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	immediate = {
 		create_character = {
 			random_traits = yes
@@ -119,7 +119,7 @@ province_event = {
 			trait = peasant_leader
 			trait = tough_soldier
 		}
-		
+
 		new_character = {
 			create_title = {
 				tier = DUKE
@@ -130,9 +130,9 @@ province_event = {
 				name = "PEASANT_REVOLT"
 				holder = THIS
 			}
-			
+
 			wealth = 100
-			
+
 			random_list = {
 				17 = {
 					spawn_unit = {
@@ -147,6 +147,8 @@ province_event = {
 							light_infantry = { 10 10 }
 						}
 						attrition = 1.0
+						cannot_inherit = yes
+						disband_on_peace = yes
 					}
 					create_character = {
 						random_traits = yes
@@ -170,6 +172,7 @@ province_event = {
 								light_infantry = { 10 10 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -195,6 +198,7 @@ province_event = {
 								light_infantry = { 10 10 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -212,6 +216,8 @@ province_event = {
 							light_infantry = { 10 10 }
 						}
 						attrition = 1.0
+						cannot_inherit = yes
+						disband_on_peace = yes
 					}
 					create_character = {
 						random_traits = yes
@@ -235,6 +241,7 @@ province_event = {
 								light_infantry = { 10 10 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -260,6 +267,7 @@ province_event = {
 								light_infantry = { 10 10 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -277,6 +285,8 @@ province_event = {
 							light_infantry = { 11 11 }
 						}
 						attrition = 1.0
+						cannot_inherit = yes
+						disband_on_peace = yes
 					}
 					create_character = {
 						random_traits = yes
@@ -300,6 +310,7 @@ province_event = {
 								light_infantry = { 11 11 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -325,6 +336,7 @@ province_event = {
 								light_infantry = { 11 11 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -341,7 +353,8 @@ province_event = {
 							light_cavalry = { 3 3 }
 							light_infantry = { 11 11 }
 						}
-						attrition = 1.0
+						cannot_inherit = yes
+						disband_on_peace = yes
 					}
 					create_character = {
 						random_traits = yes
@@ -365,6 +378,7 @@ province_event = {
 								light_infantry = { 11 11 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -390,6 +404,7 @@ province_event = {
 								light_infantry = { 11 11 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -406,6 +421,8 @@ province_event = {
 							light_infantry = { 14 14 }
 						}
 						attrition = 1.0
+						cannot_inherit = yes
+						disband_on_peace = yes
 					}
 					create_character = {
 						random_traits = yes
@@ -428,6 +445,7 @@ province_event = {
 								light_infantry = { 14 14 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -452,6 +470,7 @@ province_event = {
 								light_infantry = { 14 14 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -468,6 +487,8 @@ province_event = {
 							light_infantry = { 14 14 }
 						}
 						attrition = 1.0
+						cannot_inherit = yes
+						disband_on_peace = yes
 					}
 					create_character = {
 						random_traits = yes
@@ -490,6 +511,7 @@ province_event = {
 								light_infantry = { 14 14 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -514,12 +536,13 @@ province_event = {
 								light_infantry = { 14 14 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
 				}
 			}
-			
+
 			# DoW on the province top liege
 			ROOT = {
 				owner = {
@@ -538,7 +561,7 @@ province_event = {
 				}
 			}
 		}
-		
+
 		owner = {
 			any_liege = { # Inform the lieges
 				character_event = {
@@ -547,7 +570,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA_TOG_1000"
 	}
@@ -558,9 +581,9 @@ character_event = {
 	desc = EVTDESC_TOG_1001
 	picture = GFX_evt_peasants
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA_TOG_1000"
 	}
@@ -570,20 +593,20 @@ character_event = {
 character_event = {
 	id = TOG.1005
 	picture = GFX_evt_siege
-	
+
 	hide_window = yes
 	is_triggered_only = yes
-	
+
 	desc = OK
-	
+
 	trigger = {
 		trait = peasant_leader
 		rebel = yes
-		FROM = { 
+		FROM = {
 			is_capital = yes # The capital holding
 		}
 	}
-	
+
 	immediate = {
 		FROM = {
 			location = {
@@ -599,7 +622,7 @@ character_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = OK
 	}
@@ -612,12 +635,12 @@ province_event = {
 	desc = EVTDESC_TOG_1010
 	picture = GFX_evt_peasants
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
 
 	trigger = {
 		has_dlc = "The Old Gods"
-		
+
 		any_province_holding = {
 			NOT = { holding_type = nomad }
 		}
@@ -634,14 +657,14 @@ province_event = {
 			}
 		}
 	}
-	
+
 	immediate = {
-		
+
 		add_province_modifier = {
 			name = recent_county_uprising
 			duration = 1825 # Five years of -100% revolt risk in this county
 		}
-		
+
 		owner = {
 			top_liege = {
 				any_war = {
@@ -675,6 +698,8 @@ province_event = {
 											light_infantry = { 10 10 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
+										disband_on_peace = yes
 									}
 								}
 								create_character = {
@@ -699,6 +724,7 @@ province_event = {
 											light_infantry = { 10 10 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -724,6 +750,7 @@ province_event = {
 											light_infantry = { 10 10 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -751,6 +778,8 @@ province_event = {
 											light_infantry = { 10 10 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
+										disband_on_peace = yes
 									}
 								}
 								create_character = {
@@ -775,6 +804,7 @@ province_event = {
 											light_infantry = { 10 10 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -800,6 +830,7 @@ province_event = {
 											light_infantry = { 10 10 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -851,6 +882,7 @@ province_event = {
 											light_infantry = { 11 11 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -876,6 +908,7 @@ province_event = {
 											light_infantry = { 11 11 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -902,7 +935,8 @@ province_event = {
 											light_cavalry = { 3 3 }
 											light_infantry = { 11 11 }
 										}
-										attrition = 1.0
+										cannot_inherit = yes
+										disband_on_peace = yes
 									}
 								}
 								create_character = {
@@ -927,6 +961,7 @@ province_event = {
 											light_infantry = { 11 11 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -952,6 +987,7 @@ province_event = {
 											light_infantry = { 11 11 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -978,6 +1014,8 @@ province_event = {
 											light_infantry = { 14 14 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
+										disband_on_peace = yes
 									}
 								}
 								create_character = {
@@ -1001,6 +1039,7 @@ province_event = {
 											light_infantry = { 14 14 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -1025,6 +1064,7 @@ province_event = {
 											light_infantry = { 14 14 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -1051,6 +1091,8 @@ province_event = {
 											light_infantry = { 14 14 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
+										disband_on_peace = yes
 									}
 								}
 								create_character = {
@@ -1074,6 +1116,7 @@ province_event = {
 											light_infantry = { 14 14 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -1098,6 +1141,7 @@ province_event = {
 											light_infantry = { 14 14 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -1107,7 +1151,7 @@ province_event = {
 				}
 			}
 		}
-		
+
 		owner = {
 			any_liege = { # Inform the lieges
 				character_event = {
@@ -1116,7 +1160,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA_TOG_1010"
 	}
@@ -1127,9 +1171,9 @@ character_event = {
 	desc = EVTDESC_TOG_1011
 	picture = GFX_evt_peasants
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA_TOG_1010"
 	}
@@ -1142,14 +1186,14 @@ province_event = {
 	desc = EVTDESC_TOG_1020
 	picture = GFX_evt_heretic
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
 
 	trigger = {
 		has_dlc = "The Old Gods"
-		
+
 		is_heretic = yes
-		
+
 		any_province_holding = {
 			NOT = { holding_type = nomad }
 		}
@@ -1159,7 +1203,7 @@ province_event = {
 				is_parent_religion = ROOT
 			}
 		}
-		
+
 		NOT = { # Not if there is already an ongoing revolt
 			owner = {
 				top_liege = {
@@ -1185,7 +1229,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	immediate = {
 		create_character = {
 			random_traits = yes
@@ -1203,10 +1247,10 @@ province_event = {
 			trait = scholar
 			trait = skilled_tactician
 		}
-		
+
 		new_character = {
 			set_character_flag = heretic_revolter
-			
+
 			create_title = {
 				tier = DUKE
 				landless = yes
@@ -1216,9 +1260,9 @@ province_event = {
 				name = "HERETIC_REVOLT"
 				holder = THIS
 			}
-			
+
 			wealth = 100
-			
+
 			random_list = {
 				34 = {
 					spawn_unit = {
@@ -1233,6 +1277,8 @@ province_event = {
 							light_infantry = { 10 10 }
 						}
 						attrition = 1.0
+						cannot_inherit = yes
+						disband_on_peace = yes
 					}
 					create_character = {
 						random_traits = yes
@@ -1256,6 +1302,7 @@ province_event = {
 								light_infantry = { 10 10 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -1281,6 +1328,7 @@ province_event = {
 								light_infantry = { 10 10 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -1298,6 +1346,8 @@ province_event = {
 							light_infantry = { 12 12 }
 						}
 						attrition = 1.0
+						cannot_inherit = yes
+						disband_on_peace = yes
 					}
 					create_character = {
 						random_traits = yes
@@ -1321,6 +1371,7 @@ province_event = {
 								light_infantry = { 12 12 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -1346,6 +1397,7 @@ province_event = {
 								light_infantry = { 12 12 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -1362,6 +1414,8 @@ province_event = {
 							light_infantry = { 14 14 }
 						}
 						attrition = 1.0
+						cannot_inherit = yes
+						disband_on_peace = yes
 					}
 					create_character = {
 						random_traits = yes
@@ -1384,6 +1438,7 @@ province_event = {
 								light_infantry = { 14 14 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -1408,12 +1463,13 @@ province_event = {
 								light_infantry = { 14 14 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
 				}
 			}
-			
+
 			# DoW on the province top liege
 			ROOT = {
 				owner = {
@@ -1430,7 +1486,7 @@ province_event = {
 				}
 			}
 		}
-		
+
 		owner = {
 			any_liege = { # Inform the lieges
 				character_event = {
@@ -1439,7 +1495,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA_TOG_1020"
 	}
@@ -1450,9 +1506,9 @@ character_event = {
 	desc = EVTDESC_TOG_1021
 	picture = GFX_evt_heretic
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = EVTOPTA_TOG_1020
 	}
@@ -1462,20 +1518,20 @@ character_event = {
 character_event = {
 	id = TOG.1025
 	picture = GFX_evt_siege
-	
+
 	hide_window = yes
 	is_triggered_only = yes
-	
+
 	desc = OK
-	
+
 	trigger = {
 		trait = heresiarch
 		rebel = yes
-		FROM = { 
+		FROM = {
 			is_capital = yes # The capital holding
 		}
 	}
-	
+
 	immediate = {
 		FROM = {
 			location = {
@@ -1500,7 +1556,7 @@ character_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = OK
 	}
@@ -1513,20 +1569,20 @@ province_event = {
 	desc = EVTDESC_TOG_1030
 	picture = GFX_evt_heretic
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
 
 	trigger = {
 		has_dlc = "The Old Gods"
-		
+
 		is_heretic = yes
-		
+
 		owner = {
 			top_liege = {
 				is_parent_religion = ROOT
 			}
 		}
-		
+
 		any_province_holding = {
 			NOT = { holding_type = nomad }
 		}
@@ -1542,14 +1598,14 @@ province_event = {
 			}
 		}
 	}
-	
+
 	immediate = {
-	
+
 		add_province_modifier = {
 			name = recent_county_uprising
 			duration = 1825 # Five years of -100% revolt risk in this county
 		}
-	
+
 		owner = {
 			top_liege = {
 				any_war = {
@@ -1583,6 +1639,8 @@ province_event = {
 											light_infantry = { 10 10 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
+										disband_on_peace = yes
 									}
 								}
 								create_character = {
@@ -1607,6 +1665,7 @@ province_event = {
 											light_infantry = { 10 10 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -1632,6 +1691,7 @@ province_event = {
 											light_infantry = { 10 10 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -1659,6 +1719,8 @@ province_event = {
 											light_infantry = { 12 12 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
+										disband_on_peace = yes
 									}
 								}
 								create_character = {
@@ -1683,6 +1745,7 @@ province_event = {
 											light_infantry = { 12 12 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -1708,6 +1771,7 @@ province_event = {
 											light_infantry = { 12 12 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -1734,6 +1798,8 @@ province_event = {
 											light_infantry = { 14 14 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
+										disband_on_peace = yes
 									}
 								}
 								create_character = {
@@ -1757,6 +1823,7 @@ province_event = {
 											light_infantry = { 14 14 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -1781,6 +1848,7 @@ province_event = {
 											light_infantry = { 14 14 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -1790,7 +1858,7 @@ province_event = {
 				}
 			}
 		}
-		
+
 		owner = {
 			any_liege = { # Inform the lieges
 				character_event = {
@@ -1799,7 +1867,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA_TOG_1030"
 	}
@@ -1810,9 +1878,9 @@ character_event = {
 	desc = EVTDESC_TOG_1031
 	picture = GFX_evt_heretic
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA_TOG_1030"
 	}
@@ -1825,7 +1893,7 @@ province_event = {
 	desc = EVTDESC_TOG_1040
 	picture = GFX_evt_siege
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
 
 	trigger = {
@@ -1834,17 +1902,17 @@ province_event = {
 		any_province_holding = {
 			NOT = { holding_type = nomad }
 		}
-		
+
 		owner = {
 			top_liege = {
 				NOT = { culture = ROOT }
 			}
 		}
-		
+
 		kingdom = {
 			has_holder = no
 			culture = ROOT
-			
+
 			# The de jure kingdom must have had an appropriate holder in the past
 			any_previous_holder = {
 				ROOT = {
@@ -1860,9 +1928,9 @@ province_event = {
 				}
 			}
 		}
-		
+
 		# Heretic revolts have prio
-		OR = { 
+		OR = {
 			is_heretic = no
 			owner = {
 				top_liege = {
@@ -1870,7 +1938,7 @@ province_event = {
 				}
 			}
 		}
-		
+
 		NOT = { # Not if there is already an ongoing revolt
 			owner = {
 				top_liege = {
@@ -1898,7 +1966,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	immediate = {
 		create_character = {
 			random_traits = yes
@@ -1920,10 +1988,10 @@ province_event = {
 			trait = brilliant_strategist
 			trait = inspiring_leader
 		}
-		
+
 		new_character = {
 			set_character_flag = nationalist_rebel
-			
+
 			create_title = {
 				tier = DUKE
 				landless = yes
@@ -1933,9 +2001,9 @@ province_event = {
 				name = "NATIONALIST_REVOLT"
 				holder = THIS
 			}
-			
+
 			wealth = 100
-			
+
 			spawn_unit = {
 				province = ROOT
 				home = ROOT
@@ -1950,8 +2018,10 @@ province_event = {
 					heavy_infantry = { 3 3 }
 				}
 				attrition = 1.0
+				cannot_inherit = yes
+				disband_on_peace = yes
 			}
-			
+
 			create_character = {
 				random_traits = yes
 				dynasty = none
@@ -1978,9 +2048,11 @@ province_event = {
 						light_infantry = { 7 7 }
 						heavy_infantry = { 3 3 }
 					}
+					cannot_inherit = yes
+					disband_on_peace = yes
 				}
 			}
-			
+
 			create_character = {
 				random_traits = yes
 				dynasty = none
@@ -2007,9 +2079,11 @@ province_event = {
 						light_infantry = { 7 7 }
 						heavy_infantry = { 3 3 }
 					}
+					cannot_inherit = yes
+					disband_on_peace = yes
 				}
 			}
-			
+
 			# DoW on the province top liege
 			ROOT = {
 				owner = {
@@ -2028,7 +2102,7 @@ province_event = {
 				}
 			}
 		}
-		
+
 		owner = {
 			any_liege = { # Inform the lieges
 				character_event = {
@@ -2037,7 +2111,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA_TOG_1040"
 	}
@@ -2048,9 +2122,9 @@ character_event = {
 	desc = EVTDESC_TOG_1041
 	picture = GFX_evt_siege
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = EVTOPTA_TOG_1040
 	}
@@ -2060,15 +2134,15 @@ character_event = {
 character_event = {
 	id = TOG.1045
 	picture = GFX_evt_siege
-	
+
 	hide_window = yes
 	is_triggered_only = yes
-	
+
 	desc = OK
-	
+
 	trigger = {
 		rebel = yes
-		FROM = { 
+		FROM = {
 			is_capital = yes # The capital holding
 		}
 		any_war = {
@@ -2076,7 +2150,7 @@ character_event = {
 			using_cb = liberation_revolt
 		}
 	}
-	
+
 	immediate = {
 		FROM = {
 			location = {
@@ -2103,7 +2177,7 @@ character_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = OK
 	}
@@ -2116,7 +2190,7 @@ province_event = {
 	desc = EVTDESC_TOG_1050
 	picture = GFX_evt_siege
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
 
 	trigger = {
@@ -2125,7 +2199,7 @@ province_event = {
 		any_province_holding = {
 			NOT = { holding_type = nomad }
 		}
-		
+
 		# There is already an ongoing nationalist revolt for the same kingdom
 		owner = {
 			top_liege = {
@@ -2144,7 +2218,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	immediate = {
 		owner = {
 			top_liege = {
@@ -2187,6 +2261,8 @@ province_event = {
 									light_infantry = { 7 7 }
 									heavy_infantry = { 3 3 }
 								}
+								cannot_inherit = yes
+								disband_on_peace = yes
 							}
 						}
 						create_character = {
@@ -2215,6 +2291,8 @@ province_event = {
 									light_infantry = { 7 7 }
 									heavy_infantry = { 3 3 }
 								}
+								cannot_inherit = yes
+								disband_on_peace = yes
 							}
 						}
 						create_character = {
@@ -2243,13 +2321,15 @@ province_event = {
 									light_infantry = { 7 7 }
 									heavy_infantry = { 3 3 }
 								}
+								cannot_inherit = yes
+								disband_on_peace = yes
 							}
 						}
 					}
 				}
 			}
 		}
-		
+
 		owner = {
 			any_liege = { # Inform the lieges
 				character_event = {
@@ -2258,7 +2338,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA_TOG_1000"
 	}
@@ -2269,9 +2349,9 @@ character_event = {
 	desc = EVTDESC_TOG_1051
 	picture = GFX_evt_siege
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = EVTOPTA_TOG_1000
 	}
@@ -2284,24 +2364,24 @@ province_event = {
 	desc = EVTDESC_TOG_1060
 	picture = GFX_evt_heretic
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
 
 	trigger = {
 		has_dlc = "The Old Gods"
-		
+
 		is_heretic = no
 
 		any_province_holding = {
 			NOT = { holding_type = nomad }
 		}
-		
+
 		owner = {
 			top_liege = {
 				NOT = { religion_group = ROOT }
 			}
 		}
-		
+
 		# Nationalist revolts have prio
 		OR = {
 			owner = {
@@ -2316,7 +2396,7 @@ province_event = {
 				}
 			}
 		}
-		
+
 		NOT = { # Not if there is already an ongoing revolt
 			owner = {
 				top_liege = {
@@ -2342,7 +2422,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	immediate = {
 		create_character = {
 			random_traits = yes
@@ -2359,10 +2439,10 @@ province_event = {
 			trait = scholar
 			trait = skilled_tactician
 		}
-		
+
 		new_character = {
 			set_character_flag = religious_revolter
-			
+
 			create_title = {
 				tier = DUKE
 				landless = yes
@@ -2372,9 +2452,9 @@ province_event = {
 				name = "HERETIC_REVOLT"
 				holder = THIS
 			}
-			
+
 			wealth = 100
-			
+
 			random_list = {
 				34 = {
 					spawn_unit = {
@@ -2389,6 +2469,8 @@ province_event = {
 							light_infantry = { 10 10 }
 						}
 						attrition = 1.0
+						cannot_inherit = yes
+						disband_on_peace = yes
 					}
 					create_character = {
 						random_traits = yes
@@ -2412,6 +2494,7 @@ province_event = {
 								light_infantry = { 10 10 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -2437,6 +2520,7 @@ province_event = {
 								light_infantry = { 10 10 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -2454,6 +2538,8 @@ province_event = {
 							light_infantry = { 12 12 }
 						}
 						attrition = 1.0
+						cannot_inherit = yes
+						disband_on_peace = yes
 					}
 					create_character = {
 						random_traits = yes
@@ -2477,6 +2563,7 @@ province_event = {
 								light_infantry = { 12 12 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -2502,6 +2589,7 @@ province_event = {
 								light_infantry = { 12 12 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -2518,6 +2606,8 @@ province_event = {
 							light_infantry = { 14 14 }
 						}
 						attrition = 1.0
+						cannot_inherit = yes
+						disband_on_peace = yes
 					}
 					create_character = {
 						random_traits = yes
@@ -2540,6 +2630,7 @@ province_event = {
 								light_infantry = { 14 14 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
@@ -2564,12 +2655,13 @@ province_event = {
 								light_infantry = { 14 14 }
 							}
 							attrition = 1.0
+							cannot_inherit = yes
 							disband_on_peace = yes
 						}
 					}
 				}
 			}
-			
+
 			# DoW on the province top liege
 			ROOT = {
 				owner = {
@@ -2586,7 +2678,7 @@ province_event = {
 				}
 			}
 		}
-		
+
 		owner = {
 			any_liege = { # Inform the lieges
 				character_event = {
@@ -2595,7 +2687,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = EVTOPTA_TOG_1060
 		trigger = {
@@ -2615,9 +2707,9 @@ character_event = {
 	desc = EVTDESC_TOG_1061
 	picture = GFX_evt_heretic
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = EVTOPTA_TOG_1060
 		trigger = {
@@ -2636,20 +2728,20 @@ character_event = {
 character_event = {
 	id = TOG.1065
 	picture = GFX_evt_siege
-	
+
 	hide_window = yes
 	is_triggered_only = yes
-	
+
 	desc = OK
-	
+
 	trigger = {
 		has_character_flag = religious_revolter
 		rebel = yes
-		FROM = { 
+		FROM = {
 			is_capital = yes # The capital holding
 		}
 	}
-	
+
 	immediate = {
 		FROM = {
 			location = {
@@ -2674,7 +2766,7 @@ character_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = OK
 	}
@@ -2687,24 +2779,24 @@ province_event = {
 	desc = EVTDESC_TOG_1070
 	picture = GFX_evt_heretic
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
 
 	trigger = {
 		has_dlc = "The Old Gods"
-		
+
 		is_heretic = no
 
 		any_province_holding = {
 			NOT = { holding_type = nomad }
 		}
-		
+
 		owner = {
 			top_liege = {
 				NOT = { religion_group = ROOT }
 			}
 		}
-		
+
 		owner = {
 			top_liege = {
 				war = yes
@@ -2716,14 +2808,14 @@ province_event = {
 			}
 		}
 	}
-	
+
 	immediate = {
-	
+
 		add_province_modifier = {
 			name = recent_county_uprising
 			duration = 1825 # Five years of -100% revolt risk in this county
 		}
-	
+
 		owner = {
 			top_liege = {
 				any_war = {
@@ -2757,6 +2849,8 @@ province_event = {
 											light_infantry = { 10 10 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
+										disband_on_peace = yes
 									}
 								}
 								create_character = {
@@ -2781,6 +2875,7 @@ province_event = {
 											light_infantry = { 10 10 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -2806,6 +2901,7 @@ province_event = {
 											light_infantry = { 10 10 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -2833,6 +2929,8 @@ province_event = {
 											light_infantry = { 12 12 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
+										disband_on_peace = yes
 									}
 								}
 								create_character = {
@@ -2857,6 +2955,7 @@ province_event = {
 											light_infantry = { 12 12 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -2882,6 +2981,7 @@ province_event = {
 											light_infantry = { 12 12 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -2908,6 +3008,8 @@ province_event = {
 											light_infantry = { 14 14 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
+										disband_on_peace = yes
 									}
 								}
 								create_character = {
@@ -2931,6 +3033,7 @@ province_event = {
 											light_infantry = { 14 14 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -2955,6 +3058,7 @@ province_event = {
 											light_infantry = { 14 14 }
 										}
 										attrition = 1.0
+										cannot_inherit = yes
 										disband_on_peace = yes
 									}
 								}
@@ -2964,7 +3068,7 @@ province_event = {
 				}
 			}
 		}
-		
+
 		owner = {
 			any_liege = { # Inform the lieges
 				character_event = {
@@ -2973,7 +3077,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA_TOG_1070"
 	}
@@ -2984,9 +3088,9 @@ character_event = {
 	desc = EVTDESC_TOG_1071
 	picture = GFX_evt_heretic
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA_TOG_1070"
 	}
@@ -2999,13 +3103,13 @@ character_event = {
 	desc = EVTDESC_TOG_1190
 	picture = GFX_evt_beheading
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
-	
+
 	trigger = {
 		new_character = {
 			rebel = yes
-			
+
 			OR = {
 				NOT = { religion = ROOT }
 				AND = {
@@ -3016,7 +3120,7 @@ character_event = {
 			}
 		}
 	}
-	
+
 	weight_multiplier = {
 		days = 1
 		modifier = {
@@ -3028,7 +3132,7 @@ character_event = {
 			is_adult = no
 		}
 	}
-	
+
 	immediate = {
 		any_liege = { # Inform the victim's lieges
 			character_event = {
@@ -3044,7 +3148,7 @@ character_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = EVTOPTA_TOG_1190
 	}
@@ -3057,13 +3161,13 @@ character_event = {
 	picture = GFX_evt_beheading
 	desc = EVTDESC_TOG_1191
 	border = GFX_event_normal_frame_war
-	
+
 	is_triggered_only = yes
-	
+
 	notification = yes
-	
+
 	ai = no
-	
+
 	option = {
 		name = EVTOPTA_TOG_1191
 	}


### PR DESCRIPTION
All of the vanilla TOG rebel spawns (esp. the nationalist rebels) are now `cannot_inherit=yes` and `disband_on_peace=yes`.

The nationalist rebels *exactly* match the troop compositions of the event troop subunits of all sampled characters with ghost armies so far, and all other properties match.