### PR TITLE
Imperial Reconquest CB more friendly to viceroyalties

### DIFF
--- a/EMF/EMF_changelog.txt
+++ b/EMF/EMF_changelog.txt
@@ -15,9 +15,10 @@ EMF 4.02 [BETA]
 		Should now always start in the correct location, and the EMF supplementary AI code ("pillage-burn") for the subsequent invasions will now consequently always be able to do its glorious job
 		Supplementary AI code will now respect marriage alliances when choosing invasion targets (hard-coded AI may still attack as per normal, however)
 	Decadence revolts are now slightly less severe and can only fire when decadence is at least 75% (to vanilla)
+	Imperial Reconquest CB now additionally usurps the target duchy title if held by an ex-vassal of the CB defender whom is now your own vassal as a result of the war, if your empire has the Imperial Administration law and the Charlemagne DLC is active (allows converting the duchy into a viceroyalty rather than suffer a potentially massive 'Feudal opinion of granted viceroyalties' malus; same behavior has always applied to the enemy top liege if the title was held by them personally)
 	Vassal limit:
 		If a ruler is over vassal limit upon succession, their heir will no longer randomly lose AI vassals unless those vassals happen to be on the border of their [sub-]realm
-	FIX: (EMF+SWMH) 1066 start: Seljuks should now usually succeed at forming Rum (balance and event chain was broken by the SWMH Eastern Expansion w/ EMF 4.0)
+	FIX: (EMF+SWMH) 1066 start: Seljuks should now usually succeed at forming Rum (balance and event chain was broken by the SWMH Eastern Expansion)
 	VANILLA FIX: Ghost armies of event troops belonging to seemingly random rulers should now no longer accrue (a root cause that's been present since TOG but apparently only an issue since 2.4/HL)
 	MINOR: Tribal Organization below Medium should now properly remove any Tribal Obligations/Focus laws
 

--- a/EMF/common/cb_types/29_imperial_reconquest.txt
+++ b/EMF/common/cb_types/29_imperial_reconquest.txt
@@ -146,6 +146,22 @@ imperial_reconquest = {
 	}
 
 	on_success_title = {
+		if = {
+			limit = {
+				has_dlc = "Charlemagne"
+				ROOT = {
+					primary_title = {
+						has_law = imperial_administration
+					}
+				}
+				holder_scope = {
+					is_liege_or_above = FROM
+				}
+			}
+			holder_scope = {
+				save_event_target_as = emf_duchy_holder
+			}
+		}
 		custom_tooltip = {
 			text = other_invasion_succ_tip
 			hidden_tooltip = {
@@ -179,7 +195,7 @@ imperial_reconquest = {
 				k_papal_state = {
 					holder_scope = {
 						if = {
-							limit = { not = { is_liege_or_above = ROOT } }
+							limit = { not = { vassal_of = ROOT } }
 							ROOT = {
 								vassalize_or_take_under_title = {
 									title = PREVPREVPREV # Target duchy
@@ -195,13 +211,24 @@ imperial_reconquest = {
 		}
 		if = {
 			limit = {
-				holder_scope = { character = FROM }
+				holder_scope = {
+					or = {
+						character = FROM
+						and = {
+							event_target:emf_duchy_holder = {
+								is_liege_or_above = ROOT
+							}
+							character = event_target:emf_duchy_holder
+						}
+					}
+				}
 			}
 			usurp_title_only = {
 				target = ROOT
 				type = invasion
 			}
 		}
+		clear_event_target = emf_duchy_holder
 	}
 
 	on_fail = {


### PR DESCRIPTION
... a little enhancement that's saved me some trouble in my Kezrüm playthrough.

This only matters when attacking king- or emperor-tier top lieges with the CB, and it wasn't possible to do correctly before patch 2.3.