### PR TITLE
Fixed doubled opinion malus for increasing crown authority

### DIFF
--- a/EMF/EMF_changelog.txt
+++ b/EMF/EMF_changelog.txt
@@ -20,6 +20,7 @@ EMF 4.02 [BETA]
 		If a ruler is over vassal limit upon succession, their heir will no longer randomly lose AI vassals unless those vassals happen to be on the border of their [sub-]realm
 	FIX: (EMF+SWMH) 1066 start: Seljuks should now usually succeed at forming Rum (balance and event chain was broken by the SWMH Eastern Expansion)
 	FIX: Starting a 'Find Title' search with 's' when playing *WITHOUT* the SWMH map will no longer crash the game
+	FIX: Since 4.0, the temporary opinion malus for raising *Crown Authority* or one of its sub-laws was accidentally doubled (it is now -15 per law or sub-law again)
 	VANILLA FIX: Ghost armies of event troops belonging to seemingly random rulers should now no longer accrue (a root cause that's been present since TOG but apparently only an issue since 2.4/HL)
 	MINOR: Tribal Organization below Medium should now properly remove any Tribal Obligations/Focus laws
 

--- a/EMF/common/opinion_modifiers/00_opinion_modifiers.txt
+++ b/EMF/common/opinion_modifiers/00_opinion_modifiers.txt
@@ -2061,7 +2061,7 @@ talent_recognized = {
 }
 
 opinion_increased_authority = {
-	opinion = -30
+	opinion = -15
 }
 
 opinion_increased_tribal_organization = {


### PR DESCRIPTION
Apparently the opinion modifier magnitude was accidentally doubled somewhere during the 2.4 compatibility patch process.  This probably explains increased Elective Monarchy faction activity, as that faction requires zero CA on the title, and it would be relatively more difficult for the AI to get away with a CA increase with twice the 10-year opinion malus.