### PR TITLE
Nomad, tribal, and theocracy stuff

### DIFF
--- a/EMF/common/on_actions/emf_on_actions.txt
+++ b/EMF/common/on_actions/emf_on_actions.txt
@@ -155,5 +155,6 @@ on_new_holder_usurpation = {
         emf_autolander.0 # Add recently-acquired modifier to counties (player-only)
         emf_coa.0 # Evaluate dynamic CoA rules (specific titles only)
         emf_laws.4 # Handle crown title usurpation
+        emf_nomad.20 # Protect the culture of conquered empty/nomadic provinces
     }
 }

--- a/EMF/decisions/emf_settlement_decisions.txt
+++ b/EMF/decisions/emf_settlement_decisions.txt
@@ -1,0 +1,59 @@
+# Settlement decisions are possible vs _all_ settlements and are shown in the Settlement Diplomacy View, not the Intrigue View. The taker is in the FROM scope.
+#
+# filter = [capital/owned/vassal_owned/sub_realm_owned/realm_owned/dynasty_owned/all]
+# ai_target_filter = [capital/owned/vassal_owned/sub_realm_owned/realm_owned/dynasty_owned/all] (which settlements for which the AI evaluates the decision.)
+#	owned: all settlements owned by the AI
+#	vassal_owned: all settlements owned by direct vassal rulers of the AI's employer
+#	sub_realm_owned: all settlements below the AI's employer
+#	realm_owned: all settlements in the same top realm as the AI
+#	dynasty_owned: all settlements owned by members of the same dynasty
+#	all: all settlements (Avoid if possible. VERY CPU-HEAVY!)
+#	
+
+settlement_decisions = {
+
+	emf_convert_tribal_to_temple = {
+		filter = owned
+		ai_target_filter = owned
+		is_high_prio = yes
+		
+		from_potential = {
+			is_theocracy = yes
+		}
+		potential = {
+			holding_type = tribal
+			holder_scope = {
+				character = FROM
+			}
+		}
+		allow = {
+			or = {
+				has_building = tb_hillfort_4
+				has_building = tb_market_town_4
+				FROM = { wealth = 100 }
+			}
+		}
+		effect = {
+			if = {
+				limit = {
+					nor = {
+						has_building = tb_hillfort_4
+						has_building = tb_market_town_4
+					}
+				}
+				FROM = { wealth = -100 }
+			}
+
+			convert_to = TEMPLE
+			refill_holding_levy = yes
+			
+			# FIXME: properly refill levies
+		}
+		revoke_allowed = {
+			always = no
+		}
+		ai_will_do = {
+			factor = 1 # On average ca 1 year before taken
+		}
+	}
+}

--- a/EMF/decisions/settlement_decisions.txt
+++ b/EMF/decisions/settlement_decisions.txt
@@ -20,7 +20,6 @@ settlement_decisions = {
 		from_potential = {
 			is_feudal = yes
 		}
-		
 		potential = {
 			holding_type = tribal
 			holder_scope = {
@@ -30,62 +29,25 @@ settlement_decisions = {
 		allow = {
 			or = {
 				has_building = tb_hillfort_4
-				has_building = tb_market_town_4
+				FROM = { wealth = 100 }
 			}
 		}
 		effect = {
+			if = {
+				limit = {
+					not = { has_building = tb_hillfort_4 }
+				}
+				FROM = { wealth = -100 }
+			}
+
 			convert_to = CASTLE
 			refill_holding_levy = yes
-			
-			hidden_tooltip = {
-				if = {
-					limit = {
-						is_capital = yes
-						dejure_liege_title = {
-							location = {
-								num_of_empty_holdings = 2
-							}
-							NOT = {
-								any_direct_de_jure_vassal_title = {
-									holding_type = city
-								}
-							}
-						}
-					}
-					location = {
-						build_holding = {
-							type = city
-						}
-					}
-				}
-				
-				if = {
-					limit = {
-						is_capital = yes
-						dejure_liege_title = {
-							location = {
-								num_of_empty_holdings = 2
-							}
-							NOT = {
-								any_direct_de_jure_vassal_title = {
-									holding_type = temple
-								}
-							}
-						}
-					}
-					location = {
-						build_holding = {
-							type = temple
-						}
-					}
-				}
-			}
+
+			# FIXME: properly refill levies
 		}
-		
 		revoke_allowed = {
 			always = no
 		}
-		
 		ai_will_do = {
 			factor = 1
 		}
@@ -99,7 +61,6 @@ settlement_decisions = {
 		from_potential = {
 			is_republic = yes
 		}
-		
 		potential = {
 			holding_type = tribal
 			holder_scope = {
@@ -108,57 +69,22 @@ settlement_decisions = {
 		}
 		allow = {
 			or = {
-				has_building = tb_hillfort_4
 				has_building = tb_market_town_4
+				FROM = { wealth = 100 }
 			}
 		}
 		effect = {
+			if = {
+				limit = {
+					not = { has_building = tb_market_town_4 }
+				}
+				FROM = { wealth = -100 }
+			}
+
 			convert_to = CITY
 			refill_holding_levy = yes
 			
-			hidden_tooltip = {
-				if = {
-					limit = {
-						is_capital = yes
-						dejure_liege_title = {
-							location = {
-								num_of_empty_holdings = 2
-							}
-							NOT = {
-								any_direct_de_jure_vassal_title = {
-									holding_type = castle
-								}
-							}
-						}
-					}
-					location = {
-						build_holding = {
-							type = castle
-						}
-					}
-				}
-				
-				if = {
-					limit = {
-						is_capital = yes
-						dejure_liege_title = {
-							location = {
-								num_of_empty_holdings = 2
-							}
-							NOT = {
-								any_direct_de_jure_vassal_title = {
-									holding_type = temple
-								}
-							}
-						}
-					}
-					location = {
-						build_holding = {
-							type = temple
-						}
-					}
-				}
-			}
+			# FIXME: properly refill holding levies
 		}
 		revoke_allowed = {
 			always = no

--- a/EMF/decisions/settlement_decisions.txt
+++ b/EMF/decisions/settlement_decisions.txt
@@ -400,6 +400,11 @@ settlement_decisions = {
 				factor = 0
 				NOT = { holding_type = tribal }
 			}
+			modifier = { # Magyars shouldn't pillage Hungary before they settle there
+				factor = 0
+				de_jure_liege_or_above = k_hungary
+				FROM = { culture = hungarian }
+			}
 		}
 	}
 	

--- a/EMF/decisions/settlement_decisions.txt
+++ b/EMF/decisions/settlement_decisions.txt
@@ -28,8 +28,9 @@ settlement_decisions = {
 			}
 		}
 		allow = {
-			location = {
-				religion = FROM
+			or = {
+				has_building = tb_hillfort_4
+				has_building = tb_market_town_4
 			}
 		}
 		effect = {
@@ -106,8 +107,9 @@ settlement_decisions = {
 			}
 		}
 		allow = {
-			location = {
-				religion = FROM
+			or = {
+				has_building = tb_hillfort_4
+				has_building = tb_market_town_4
 			}
 		}
 		effect = {
@@ -225,6 +227,9 @@ settlement_decisions = {
 					}
 				}
 			}
+
+			# NOTE: What if none of the settlement types are preferred but at least 2 are allowed?
+			# Could we get into a situation where the AI is flip-flopping capitals around continuously?
 		}
 	}
 	

--- a/EMF/decisions/settlement_decisions.txt
+++ b/EMF/decisions/settlement_decisions.txt
@@ -217,14 +217,12 @@ settlement_decisions = {
 					NOT = { has_province_modifier = recently_burnt_the_land_not_owner }
 				}
 			}
-			OR = {
-				owner = {
-					character = FROM
-				}
+			or = {
+				holder_scope = { character = FROM }
 				num_of_buildings = 4
 			}
-			OR = {
-				FROM = {
+			FROM = {
+				or = {
 					independent = yes
 					
 					custom_tooltip = { 
@@ -248,79 +246,89 @@ settlement_decisions = {
 		}
 		effect = {
 			if = {
-				limit = { NOT = { holding_type = tribal } }
-				FROM = {
-					if = {
-						limit = {
-							location = {
-								owner = {
-									character = FROM
-								}
-							}
-						}
-						wealth = 50
+				limit = { not = { holding_type = tribal } }
+				if = {
+					limit = {
+						location = { owner = { character = FROM } }
 					}
-					if = {
-						limit = {
-							NOT = {
-								location = {
-									owner = {
-										character = FROM
-									}
-								}
-							}
-						}
-						wealth = 10
+					custom_tooltip = {
+						text = emf_nomad_ctt_plunder_from_nontribal
+						hidden_tooltip = { FROM = { wealth = 50 } }
 					}
-					random_list = {
-						10 = { military_techpoints = 10 }
-						10 = { economy_techpoints = 10 }
-						10 = { culture_techpoints = 10 }
+				}
+				if = {
+					limit = {
+						location = { owner = { not = { character = FROM } } }
+					}
+					custom_tooltip = {
+						text = emf_nomad_ctt_plunder_from_nontribal_not_owner
+						hidden_tooltip = { FROM = { wealth = 10 } }
+					}
+				}
+				hidden_tooltip = {
+					FROM = {
+						random_list = {
+							10 = { military_techpoints = 10 }
+							10 = { economy_techpoints  = 10 }
+							10 = { culture_techpoints  = 10 }
+						}
 					}
 				}
 			}
 			if = {
 				limit = { holding_type = tribal }
-				FROM = {
-					if = {
-						limit = {
-							owner = {
-								character = FROM
-							}
-						}
-						wealth = 25
+				if = {
+					limit = {
+						location = { owner = { character = FROM } }
 					}
-					if = {
-						limit = {
-							NOT = {
-								owner = {
-									character = FROM
-								}
-							}
-						}
-						wealth = 5
+					custom_tooltip = {
+						text = emf_nomad_ctt_plunder_from_tribal
+						hidden_tooltip = { FROM = { wealth = 25 } }
 					}
-					random_list = {
-						10 = { military_techpoints = 2 }
-						10 = { economy_techpoints = 2 }
-						10 = { culture_techpoints = 2 }
+				}
+				if = {
+					limit = {
+						location = { owner = { not = { character = FROM } } }
+					}
+					custom_tooltip = {
+						text = emf_nomad_ctt_plunder_from_tribal_not_owner
+						hidden_tooltip = { FROM = { wealth = 5 } }
+					}
+				}
+				hidden_tooltip = {
+					FROM = {
+						random_list = {
+							10 = { military_techpoints = 2 }
+							10 = { economy_techpoints  = 2 }
+							10 = { culture_techpoints  = 2 }
+						}
 					}
 				}
 			}
 
-			location = {
-				if = {
-					limit = { 
-						any_province_holding = {
-							NOT = { holding_type = nomad }
-						}
-					}
-					if = {
-						limit = { 
-							owner = { 
-								character = FROM
+			if = {
+				limit = { # Destroy the settlement?
+					owner = { character = FROM }
+					not = { num_of_buildings = 3 }
+					or = {
+						FROM = { ai = no } # Player can destroy whatever he owns
+						location = {
+							or = {
+								culture = FROM # Must have same culture, or...
+								any_province_holding = { # Another holding
+									nor = {
+										title = ROOT
+										holding_type = nomad
+									}
+								}
 							}
 						}
+					}
+				}
+				custom_tooltip = { text = emf_nomad_ctt_pillage_destroy_settlement }
+				location = {
+					if = {
+						limit = { owner = { character = FROM } }
 						add_province_modifier = {
 							modifier = burnt_the_land
 							years = 8
@@ -332,53 +340,54 @@ settlement_decisions = {
 						}
 					}
 					if = {
-						limit = {
-							NOT = {
-								owner = { 
-									character = FROM
-								}
-							}
-						}
+						limit = { owner = { not = { character = FROM } } }
 						add_province_modifier = {
 							modifier = recently_burnt_the_land_not_owner
 							years = 10
 						}
 					}
 				}
+				hidden_tooltip = { destroy_settlement = THIS }
+				break = yes
 			}
 
+			# Just destroy buildings...
+
 			custom_tooltip = {
-				text = "PILLAGE_DESTROY_BUILDINGS"
+				text = emf_nomad_ctt_pillage_destroy_buildings
 				hidden_tooltip = {
 					if = {
-						limit = { 
-							owner = { 
-								character = FROM
-							}
-						}
+						limit = { owner = { character = FROM } }
 						destroy_random_building = THIS
 						destroy_random_building = THIS
 					}
 					if = {
-						limit = {
-							NOT = {
-								owner = { 
-									character = FROM
-								}
-							}
-						}
+						limit = { owner = { not = { character = FROM } } }
 						destroy_random_building = THIS
 					}
 				}
 			}
-			if = {
-				limit = {
-					NOT = { has_any_building = yes }
-					owner = {
-						character = FROM
+
+			location = {
+				if = {
+					limit = { owner = { character = FROM } }
+					add_province_modifier = {
+						modifier = burnt_the_land
+						years = 8
+						stacking = yes
+					}
+					add_province_modifier = {
+						modifier = recently_burnt_the_land
+						months = 6
 					}
 				}
-				destroy_settlement = THIS
+				if = {
+					limit = { owner = { not = { character = FROM } } }
+					add_province_modifier = {
+						modifier = recently_burnt_the_land_not_owner
+						years = 10
+					}
+				}
 			}
 		}
 		revoke_allowed = {

--- a/EMF/events/emf_nomad.txt
+++ b/EMF/events/emf_nomad.txt
@@ -396,3 +396,77 @@ character_event = {
 		repeat_event = { id = emf_nomad.5 }
 	}
 }
+
+# emf_nomad.20 [New Empty County Holder]
+#
+# on_new_holder_usurpation listener for empty/nomadic provinces that enforces
+# the equivalent of the scripted effect emf_cb_nomadic_province_effect upon
+# all usurped empty counties.
+#
+# The scripted effect is still used throughout CBs, because this method needs to
+# convert culture/religion _back_ to what it was before the title transfer, and
+# if our CB code didn't try to minimize usage of this fall-back method, then
+# it's possible that SoA heresy-takeover mechanics could be triggered by some
+# conquests when they should not be.
+#
+# This should be considered the general, catch-all case for ensuring the invariant
+# that non-nomadic rulers conquering (or event-usurping) empty counties or nomadic
+# rulers of different culture than such a conquered county will always receive a
+# county with a new tribal settlement in it (and the province should be the prior
+# culture). NOTE: We don't listen to regular on_new_holder, because we don't
+# want this behavior for title grants/gains, which should be exempt. Some CBs use
+# such methods, so again, a mixed approach is necessary.
+#
+# If the logic here is updated, then the aforementioned scripted effect should
+# also be updated.
+#
+# As always:
+#   ROOT = new holder
+#   FROM = title
+#   FROMFROM = previous holder
+character_event = {
+	id = emf_nomad.20
+	hide_window = yes
+	is_triggered_only = yes
+
+	trigger = {
+		FROM = { tier = count } # Filter only county titles ...
+		FROM = { # ... that correspond to empty/nomadic provinces.
+			location = {
+				not = {
+					any_province_holding = {
+						not = { holding_type = nomad }
+					}
+				}
+			}
+		}
+		# And the new holder isn't a nomad, or the culture of the new & prior
+		# holders is not the same.
+		ROOT = {
+			or = {
+				is_nomadic = no
+				not = { culture = FROMFROM }
+			}
+		}
+		# We depend upon being able to query character religion/culture, so this
+		# is here as a sort of assertion:
+		FROMFROM = { is_alive = yes }
+	}
+
+	immediate = {
+		FROM = {
+			location = {
+				build_holding = { type = tribal }
+				random_province_holding = {
+					limit = {
+						holding_type = tribal
+						ROOT = { is_nomadic = no }
+					}
+					make_capital_holding = yes
+				}
+				religion = FROMFROM
+				culture = FROMFROM
+			}
+		}
+	}
+}

--- a/EMF/localisation/emf_core.csv
+++ b/EMF/localisation/emf_core.csv
@@ -1,7 +1,4 @@
 #CODE;ENGLISH;FRENCH;GERMAN;;SPANISH;;;;;;;;;x
-#### BUILDINGS;;;;;;;;;;;;;;x
-no_lucky_desc;AI bonus for nomad Lucky Rulers.;;;;;;;;;;;;;x
-no_lucky_1;Lucky Warhorse Stables;;;;;;;;;;;;;x
 #### DECISIONS;;;;;;;;;;;;;;x
 emf_bring_child_home;Bring Child Home;;;;;;;;;;;;;x
 emf_bring_child_home_desc;Bring a wayward child home.;;;;;;;;;;;;;x

--- a/EMF/localisation/emf_core.csv
+++ b/EMF/localisation/emf_core.csv
@@ -3,11 +3,12 @@
 no_lucky_desc;AI bonus for nomad Lucky Rulers.;;;;;;;;;;;;;x
 no_lucky_1;Lucky Warhorse Stables;;;;;;;;;;;;;x
 #### DECISIONS;;;;;;;;;;;;;;x
-emf_toggle_customization;Toggle Customization Decisions;;;;;;;;;;;;;x
-emf_toggle_customization_desc;Hide/show various customization decisions.;;;;;;;;;;;;;x
 emf_bring_child_home;Bring Child Home;;;;;;;;;;;;;x
 emf_bring_child_home_desc;Bring a wayward child home.;;;;;;;;;;;;;x
 emf_bring_child_home_named;Bring [Root.GetFirstName] home.;;;;;;;;;;;;;x
+emf_convert_tribal_to_temple;Upgrade to Temple;;;;;;;;;;;;;x
+emf_convert_tribal_to_temple_named;Upgrade [Root.GetName] to a Temple;;;;;;;;;;;;;x
+emf_convert_tribal_to_temple_desc;I can upgrade [Root.GetFullName] to a proper Temple.;;;;;;;;;;;;;x
 emf_court_banishment;Banish from Court;;;;;;;;;;;;;x
 emf_court_banishment_desc;As your guest at court, §Y[Root.GetTitledName]§! can be sent away if [Root.GetSubjectPronoun] is not a prisoner, a child, or working for you in an official capacity.;;;;;;;;;;;;;x
 emf_court_banishment_named;Banish [Root.GetFirstName] from your court.;;;;;;;;;;;;;x
@@ -15,6 +16,8 @@ emf_create_hre;Form the Holy Roman Empire;;;;;;;;;;;;;x
 emf_create_hre_desc;Reclaim Charlemagne's legacy as the protector of Rome and found the Holy Roman Empire.;;;;;;;;;;;;;x
 emf_create_french_hre;Form the Frankish HRE;;;;;;;;;;;;;x
 emf_create_french_hre_desc;Reclaim Charlemagne's legacy as the protector of Rome and found the Saint-Empire Romain.;;;;;;;;;;;;;x
+emf_toggle_customization;Toggle Customization Decisions;;;;;;;;;;;;;x
+emf_toggle_customization_desc;Hide/show various customization decisions.;;;;;;;;;;;;;x
 #### MISCELLANEOUS;;;;;;;;;;;;;;x
 ERA_CHAR_INFO_122; ;;;;;;;;;;;;;x
 #### OPINION MODIFIERS;;;;;;;;;;;;;;x

--- a/EMF/localisation/emf_nomad.csv
+++ b/EMF/localisation/emf_nomad.csv
@@ -1,0 +1,11 @@
+#CODE;ENGLISH;FRENCH;GERMAN;;SPANISH;;;;;;;;;x
+#### BUILDINGS;;;;;;;;;;;;;;x
+no_lucky_desc;AI bonus for nomad Lucky Rulers.;;;;;;;;;;;;;x
+no_lucky_1;Lucky Warhorse Stables;;;;;;;;;;;;;x
+#### TOOLTIPS;;;;;;;;;;;;;;x
+emf_nomad_ctt_pillage_destroy_settlement;This will destroy the entire settlement!\n;;;;;;;;;;;;;x
+emf_nomad_ctt_pillage_destroy_buildings;This will destroy some buildings!\n;;;;;;;;;;;;;x
+emf_nomad_ctt_plunder_from_nontribal;Plunder §Y50§!¤ and §Y10§! technology points.\n;;;;;;;;;;;;;x
+emf_nomad_ctt_plunder_from_nontribal_not_owner;Plunder §Y10§!¤ and §Y10§! technology points.\n;;;;;;;;;;;;;x
+emf_nomad_ctt_plunder_from_tribal;Plunder §Y25§!¤ and §Y2§! technology points.\n;;;;;;;;;;;;;x
+emf_nomad_ctt_plunder_from_tribal_not_owner;Plunder §Y5§!¤ and §Y2§! technology points.\n;;;;;;;;;;;;;x


### PR DESCRIPTION
- `on_new_holder_usurpation` catch-all to help enforce the new "leave behind a tribe if different culture" rule
- various vanilla fixes to `pillage_settlement`
- added an `emf_convert_tribal_to_temple` settlement decision for theocracies
- `pillage_settlement` "tooltip" (effects printed into a diplo-action window) is now much more concise & smart and should actually fit in the window
- when AI is using `pillage_settlement`, it will never actually destroy the last settlement in a different-culture province
- magyars won't pillage anything inside de jure `k_hungary`, since that's about to be their damn home
- made conditions for tribal settlement conversion (for non-tribals) require either the appropriate maxed-out building for their type OR 100 gold
- tribal settlement conversion no longer auto-builds up to 2 secondary holdings, reverting to something more like pre-HL where you need to actually bootstrap your feudal/republican realm after feudalizing (or not get a ridiculous freebie if it's a conquered tribal settlement and you weren't tribal recently/ever)