### PR TITLE
bugfix for nomad settlement that might _theoretically_ prevent a CTD

### DIFF
--- a/EMF/common/scripted_effects/emf_nomad_effects.txt
+++ b/EMF/common/scripted_effects/emf_nomad_effects.txt
@@ -1,8 +1,8 @@
 
 # Called once per empty holding in qualifying realm provinces of a nomad
-# that's about to settle.
+# that's about to settle (only provinces actually part of the nomad's
+# demesne and non-nomadic subrealm qualify).
 emf_nomad_settlement_spawn_unit_effect = {
-
 	ROOT = {
 		spawn_unit = {
 			province = event_target:emf_new_capital

--- a/EMF/events/emf_nomad.txt
+++ b/EMF/events/emf_nomad.txt
@@ -447,7 +447,7 @@ character_event = {
 					# ever actually hit this case.
 
 					log = "emf_nomad.4: INFO: found a non-nomadic county owner among emf_old_khan_claim that didn't transfer to non-nomadic realm"
-					repeat_event = { id = emf_nomad.4 }
+					ROOT = { repeat_event = { id = emf_nomad.4 } }
 					break = yes
 				}
 


### PR DESCRIPTION
Case should never actually happen, but if for some reason it did, it may have CTDed.  Now, it won't.