### PR TITLE
12 Tiered 'Increase Size of Demense' Ambitions

### DIFF
--- a/EMF/emf_obj_increase_demesne.txt
+++ b/EMF/emf_obj_increase_demesne.txt
@@ -1,0 +1,1134 @@
+# adapted from CK2+
+
+obj_increase_demesne_1 = {
+	type = character
+	
+	potential = {
+		is_playable = yes
+		is_landed = yes
+		not = { demesne_size = 2 }
+		or = {
+			ai = no
+			not = { has_character_flag = obj_demesne }
+		}
+	}
+	allow = {
+		is_adult = yes
+		not = { trait = incapable }
+		not = { over_max_demesne_size = 0 }
+	}
+	chance = {
+		factor = 50
+
+		modifier = {
+			factor = 1.5
+			prestige = 100
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 250
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 400
+		}
+		modifier = {
+			factor = 1.5
+			trait = envious
+		}
+		modifier = {
+			factor = 0.1
+			trait = humble
+		}
+		modifier = {
+			factor = 10.0
+			trait = ambitious
+		}
+		modifier = {
+			factor = 0.1
+			trait = content
+		}
+	}
+	creation_effect = {
+		if = {
+			limit = { ai = yes }
+			add_character_modifier = {
+				name = emf_objective_timer
+				duration = 1825
+				hidden = yes
+			}
+		}
+	}
+	success = {
+		demesne_size = 2
+	}
+	abort = {
+		or = {
+			trait = incapable
+			is_playable = no
+			and = {
+				ai = yes
+				not = { has_character_modifier = emf_objective_timer }
+			}
+		}
+	}
+	abort_effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+	}
+	effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+		if = {
+			limit = { not = { has_character_flag = obj_demesne } }
+			change_stewardship = 1
+			if = {
+				limit = {
+					independent = no
+					in_revolt = no
+				}
+				liege = {
+					reverse_opinion = {
+						who = ROOT
+						modifier = opinion_happy
+						months = 120
+					}
+				}
+			}
+		}
+		if = {
+			limit = { has_character_flag = obj_demesne }
+			prestige = 25
+		}
+		set_character_flag = obj_demesne
+	}
+}
+
+obj_increase_demesne_2 = {
+	type = character
+	
+	potential = {
+		is_playable = yes
+		demesne_size = 2
+		not = { demesne_size = 3 }
+		or = {
+			ai = no
+			not = { has_character_flag = obj_demesne }
+		}
+	}
+	allow = {
+		is_adult = yes
+		not = { trait = incapable }
+		not = { over_max_demesne_size = 0 }
+	}
+	chance = {
+		factor = 50
+
+		modifier = {
+			factor = 1.5
+			prestige = 100
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 250
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 400
+		}
+		modifier = {
+			factor = 1.5
+			trait = envious
+		}
+		modifier = {
+			factor = 0.1
+			trait = humble
+		}
+		modifier = {
+			factor = 10.0
+			trait = ambitious
+		}
+		modifier = {
+			factor = 0.1
+			trait = content
+		}
+	}
+	creation_effect = {
+		if = {
+			limit = { ai = yes }
+			add_character_modifier = {
+				name = emf_objective_timer
+				duration = 1825
+				hidden = yes
+			}
+		}
+	}
+	success = {
+		demesne_size = 3
+	}
+	abort = {
+		or = {
+			trait = incapable
+			is_playable = no
+			and = {
+				ai = yes
+				not = { has_character_modifier = emf_objective_timer }
+			}
+		}
+	}
+	abort_effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+	}
+	effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+		if = {
+			limit = { not = { has_character_flag = obj_demesne } }
+			change_stewardship = 1
+			if = {
+				limit = {
+					independent = no
+					in_revolt = no
+				}
+				liege = {
+					reverse_opinion = {
+						who = ROOT
+						modifier = opinion_happy
+						months = 120
+					}
+				}
+			}
+		}
+		if = {
+			limit = { has_character_flag = obj_demesne }
+			prestige = 25
+		}
+		set_character_flag = obj_demesne
+	}
+}
+
+obj_increase_demesne_3 = {
+	type = character
+	
+	potential = {
+		is_playable = yes
+		demesne_size = 3
+		not = { demesne_size = 4 }
+		or = {
+			ai = no
+			not = { has_character_flag = obj_demesne }
+		}
+	}
+	allow = {
+		is_adult = yes
+		not = { trait = incapable }
+		not = { over_max_demesne_size = 0 }
+	}
+	chance = {
+		factor = 50
+
+		modifier = {
+			factor = 1.5
+			prestige = 100
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 250
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 400
+		}
+		modifier = {
+			factor = 1.5
+			trait = envious
+		}
+		modifier = {
+			factor = 0.1
+			trait = humble
+		}
+		modifier = {
+			factor = 10.0
+			trait = ambitious
+		}
+		modifier = {
+			factor = 0.1
+			trait = content
+		}
+	}
+	creation_effect = {
+		if = {
+			limit = { ai = yes }
+			add_character_modifier = {
+				name = emf_objective_timer
+				duration = 1825
+				hidden = yes
+			}
+		}
+	}
+	success = {
+		demesne_size = 4
+	}
+	abort = {
+		or = {
+			trait = incapable
+			is_playable = no
+			and = {
+				ai = yes
+				not = { has_character_modifier = emf_objective_timer }
+			}
+		}
+	}
+	abort_effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+	}
+	effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+		if = {
+			limit = { not = { has_character_flag = obj_demesne } }
+			change_stewardship = 1
+			if = {
+				limit = {
+					independent = no
+					in_revolt = no
+				}
+				liege = {
+					reverse_opinion = {
+						who = ROOT
+						modifier = opinion_happy
+						months = 120
+					}
+				}
+			}
+		}
+		if = {
+			limit = { has_character_flag = obj_demesne }
+			prestige = 25
+		}
+		set_character_flag = obj_demesne
+	}
+}
+
+obj_increase_demesne_4 = {
+	type = character
+	
+	potential = {
+		is_playable = yes
+		demesne_size = 4
+		not = { demesne_size = 5 }
+		or = {
+			ai = no
+			not = { has_character_flag = obj_demesne }
+		}
+	}
+	allow = {
+		is_adult = yes
+		not = { trait = incapable }
+		not = { over_max_demesne_size = 0 }
+	}
+	chance = {
+		factor = 50
+
+		modifier = {
+			factor = 1.5
+			prestige = 100
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 250
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 400
+		}
+		modifier = {
+			factor = 1.5
+			trait = envious
+		}
+		modifier = {
+			factor = 0.1
+			trait = humble
+		}
+		modifier = {
+			factor = 10.0
+			trait = ambitious
+		}
+		modifier = {
+			factor = 0.1
+			trait = content
+		}
+	}
+	creation_effect = {
+		if = {
+			limit = { ai = yes }
+			add_character_modifier = {
+				name = emf_objective_timer
+				duration = 1825
+				hidden = yes
+			}
+		}
+	}
+	success = {
+		demesne_size = 5
+	}
+	abort = {
+		or = {
+			trait = incapable
+			is_playable = no
+			and = {
+				ai = yes
+				not = { has_character_modifier = emf_objective_timer }
+			}
+		}
+	}
+	abort_effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+	}
+	effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+		if = {
+			limit = { not = { has_character_flag = obj_demesne } }
+			change_stewardship = 1
+			if = {
+				limit = {
+					independent = no
+					in_revolt = no
+				}
+				liege = {
+					reverse_opinion = {
+						who = ROOT
+						modifier = opinion_happy
+						months = 120
+					}
+				}
+			}
+		}
+		if = {
+			limit = { has_character_flag = obj_demesne }
+			prestige = 25
+		}
+		set_character_flag = obj_demesne
+	}
+}
+
+obj_increase_demesne_5 = {
+	type = character
+	
+	potential = {
+		is_playable = yes
+		demesne_size = 5
+		not = { demesne_size = 6 }
+		or = {
+			ai = no
+			not = { has_character_flag = obj_demesne }
+		}
+	}
+	allow = {
+		is_adult = yes
+		not = { trait = incapable }
+		not = { over_max_demesne_size = 0 }
+	}
+	chance = {
+		factor = 50
+
+		modifier = {
+			factor = 1.5
+			prestige = 100
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 250
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 400
+		}
+		modifier = {
+			factor = 1.5
+			trait = envious
+		}
+		modifier = {
+			factor = 0.1
+			trait = humble
+		}
+		modifier = {
+			factor = 10.0
+			trait = ambitious
+		}
+		modifier = {
+			factor = 0.1
+			trait = content
+		}
+	}
+	creation_effect = {
+		if = {
+			limit = { ai = yes }
+			add_character_modifier = {
+				name = emf_objective_timer
+				duration = 1825
+				hidden = yes
+			}
+		}
+	}
+	success = {
+		demesne_size = 6
+	}
+	abort = {
+		or = {
+			trait = incapable
+			is_playable = no
+			and = {
+				ai = yes
+				not = { has_character_modifier = emf_objective_timer }
+			}
+		}
+	}
+	abort_effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+	}
+	effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+		if = {
+			limit = { not = { has_character_flag = obj_demesne } }
+			change_stewardship = 1
+			if = {
+				limit = {
+					independent = no
+					in_revolt = no
+				}
+				liege = {
+					reverse_opinion = {
+						who = ROOT
+						modifier = opinion_happy
+						months = 120
+					}
+				}
+			}
+		}
+		if = {
+			limit = { has_character_flag = obj_demesne }
+			prestige = 25
+		}
+		set_character_flag = obj_demesne
+	}
+}
+
+
+obj_increase_demesne_6 = {
+	type = character
+	
+	potential = {
+		is_playable = yes
+		demesne_size = 6
+		not = { demesne_size = 7 }
+		or = {
+			ai = no
+			not = { has_character_flag = obj_demesne }
+		}
+	}
+	allow = {
+		is_adult = yes
+		not = { trait = incapable }
+		not = { over_max_demesne_size = 0 }
+	}
+	chance = {
+		factor = 50
+
+		modifier = {
+			factor = 1.5
+			prestige = 100
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 250
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 400
+		}
+		modifier = {
+			factor = 1.5
+			trait = envious
+		}
+		modifier = {
+			factor = 0.1
+			trait = humble
+		}
+		modifier = {
+			factor = 10.0
+			trait = ambitious
+		}
+		modifier = {
+			factor = 0.1
+			trait = content
+		}
+	}
+	creation_effect = {
+		if = {
+			limit = { ai = yes }
+			add_character_modifier = {
+				name = emf_objective_timer
+				duration = 1825
+				hidden = yes
+			}
+		}
+	}
+	success = {
+		demesne_size = 7
+	}
+	abort = {
+		or = {
+			trait = incapable
+			is_playable = no
+			and = {
+				ai = yes
+				not = { has_character_modifier = emf_objective_timer }
+			}
+		}
+	}
+	abort_effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+	}
+	effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+		if = {
+			limit = { not = { has_character_flag = obj_demesne } }
+			change_stewardship = 1
+			if = {
+				limit = {
+					independent = no
+					in_revolt = no
+				}
+				liege = {
+					reverse_opinion = {
+						who = ROOT
+						modifier = opinion_happy
+						months = 120
+					}
+				}
+			}
+		}
+		if = {
+			limit = { has_character_flag = obj_demesne }
+			prestige = 25
+		}
+		set_character_flag = obj_demesne
+	}
+}
+
+obj_increase_demesne_7 = {
+	type = character
+	
+	potential = {
+		is_playable = yes
+		demesne_size = 7
+		not = { demesne_size = 8 }
+		or = {
+			ai = no
+			not = { has_character_flag = obj_demesne }
+		}
+	}
+	allow = {
+		is_adult = yes
+		not = { trait = incapable }
+		not = { over_max_demesne_size = 0 }
+	}
+	chance = {
+		factor = 50
+
+		modifier = {
+			factor = 1.5
+			prestige = 100
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 250
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 400
+		}
+		modifier = {
+			factor = 1.5
+			trait = envious
+		}
+		modifier = {
+			factor = 0.1
+			trait = humble
+		}
+		modifier = {
+			factor = 10.0
+			trait = ambitious
+		}
+		modifier = {
+			factor = 0.1
+			trait = content
+		}
+	}
+	creation_effect = {
+		if = {
+			limit = { ai = yes }
+			add_character_modifier = {
+				name = emf_objective_timer
+				duration = 1825
+				hidden = yes
+			}
+		}
+	}
+	success = {
+		demesne_size = 8
+	}
+	abort = {
+		or = {
+			trait = incapable
+			is_playable = no
+			and = {
+				ai = yes
+				not = { has_character_modifier = emf_objective_timer }
+			}
+		}
+	}
+	abort_effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+	}
+	effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+		if = {
+			limit = { not = { has_character_flag = obj_demesne } }
+			change_stewardship = 1
+			if = {
+				limit = {
+					independent = no
+					in_revolt = no
+				}
+				liege = {
+					reverse_opinion = {
+						who = ROOT
+						modifier = opinion_happy
+						months = 120
+					}
+				}
+			}
+		}
+		if = {
+			limit = { has_character_flag = obj_demesne }
+			prestige = 25
+		}
+		set_character_flag = obj_demesne
+	}
+}
+
+obj_increase_demesne_8 = {
+	type = character
+	
+	potential = {
+		is_playable = yes
+		demesne_size = 8
+		not = { demesne_size = 9 }
+		or = {
+			ai = no
+			not = { has_character_flag = obj_demesne }
+		}
+	}
+	allow = {
+		is_adult = yes
+		not = { trait = incapable }
+		not = { over_max_demesne_size = 0 }
+	}
+	chance = {
+		factor = 50
+
+		modifier = {
+			factor = 1.5
+			prestige = 100
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 250
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 400
+		}
+		modifier = {
+			factor = 1.5
+			trait = envious
+		}
+		modifier = {
+			factor = 0.1
+			trait = humble
+		}
+		modifier = {
+			factor = 10.0
+			trait = ambitious
+		}
+		modifier = {
+			factor = 0.1
+			trait = content
+		}
+	}
+	creation_effect = {
+		if = {
+			limit = { ai = yes }
+			add_character_modifier = {
+				name = emf_objective_timer
+				duration = 1825
+				hidden = yes
+			}
+		}
+	}
+	success = {
+		demesne_size = 9
+	}
+	abort = {
+		or = {
+			trait = incapable
+			is_playable = no
+			and = {
+				ai = yes
+				not = { has_character_modifier = emf_objective_timer }
+			}
+		}
+	}
+	abort_effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+	}
+	effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+		if = {
+			limit = { not = { has_character_flag = obj_demesne } }
+			change_stewardship = 1
+			if = {
+				limit = {
+					independent = no
+					in_revolt = no
+				}
+				liege = {
+					reverse_opinion = {
+						who = ROOT
+						modifier = opinion_happy
+						months = 120
+					}
+				}
+			}
+		}
+		if = {
+			limit = { has_character_flag = obj_demesne }
+			prestige = 25
+		}
+		set_character_flag = obj_demesne
+	}
+}
+
+
+obj_increase_demesne_9 = {
+	type = character
+	
+	potential = {
+		is_playable = yes
+		demesne_size = 9
+		not = { demesne_size = 10 }
+		or = {
+			ai = no
+			not = { has_character_flag = obj_demesne }
+		}
+	}
+	allow = {
+		is_adult = yes
+		not = { trait = incapable }
+		not = { over_max_demesne_size = 0 }
+	}
+	chance = {
+		factor = 50
+
+		modifier = {
+			factor = 1.5
+			prestige = 100
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 250
+		}
+		modifier = {
+			factor = 1.5
+			prestige = 400
+		}
+		modifier = {
+			factor = 1.5
+			trait = envious
+		}
+		modifier = {
+			factor = 0.1
+			trait = humble
+		}
+		modifier = {
+			factor = 10.0
+			trait = ambitious
+		}
+		modifier = {
+			factor = 0.1
+			trait = content
+		}
+	}
+	creation_effect = {
+		if = {
+			limit = { ai = yes }
+			add_character_modifier = {
+				name = emf_objective_timer
+				duration = 1825
+				hidden = yes
+			}
+		}
+	}
+	success = {
+		demesne_size = 10
+	}
+	abort = {
+		or = {
+			trait = incapable
+			is_playable = no
+			and = {
+				ai = yes
+				not = { has_character_modifier = emf_objective_timer }
+			}
+		}
+	}
+	abort_effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+	}
+	effect = {
+		if = {
+			limit = { ai = yes }
+			remove_character_modifier = emf_objective_timer
+		}
+		if = {
+			limit = { not = { has_character_flag = obj_demesne } }
+			change_stewardship = 1
+			if = {
+				limit = {
+					independent = no
+					in_revolt = no
+				}
+				liege = {
+					reverse_opinion = {
+						who = ROOT
+						modifier = opinion_happy
+						months = 120
+					}
+				}
+			}
+		}
+		if = {
+			limit = { has_character_flag = obj_demesne }
+			prestige = 25
+		}
+		set_character_flag = obj_demesne
+	}
+}
+
+obj_increase_demesne_10 = {
+	type = character
+	
+	potential = {
+		ai = no
+		demesne_size = 10
+		not = { demesne_size = 11 }
+	}
+	allow = {
+		is_adult = yes
+		not = { trait = incapable }
+		not = { over_max_demesne_size = 0 }
+	}
+	chance = {
+		factor = 0
+	}
+	success = {
+		demesne_size = 11
+	}
+	abort = {
+		or = {
+			trait = incapable
+			is_playable = no
+		}
+	}
+	abort_effect = {
+	}
+	effect = {
+		if = {
+			limit = { not = { has_character_flag = obj_demesne } }
+			change_stewardship = 1
+			if = {
+				limit = {
+					independent = no
+					in_revolt = no
+				}
+				liege = {
+					reverse_opinion = {
+						who = ROOT
+						modifier = opinion_happy
+						months = 120
+					}
+				}
+			}
+		}
+		if = {
+			limit = { has_character_flag = obj_demesne }
+			prestige = 25
+		}
+		set_character_flag = obj_demesne
+	}
+}
+
+obj_increase_demesne_11 = {
+	type = character
+	
+	potential = {
+		ai = no
+		demesne_size = 11
+		not = { demesne_size = 12 }
+	}
+	allow = {
+		is_adult = yes
+		not = { trait = incapable }
+		not = { over_max_demesne_size = 0 }
+	}
+	chance = {
+		factor = 0
+	}
+	success = {
+		demesne_size = 12
+	}
+	abort = {
+		or = {
+			trait = incapable
+			is_playable = no
+		}
+	}
+	abort_effect = {
+	}
+	effect = {
+		if = {
+			limit = { not = { has_character_flag = obj_demesne } }
+			change_stewardship = 1
+			if = {
+				limit = {
+					independent = no
+					in_revolt = no
+				}
+				liege = {
+					reverse_opinion = {
+						who = ROOT
+						modifier = opinion_happy
+						months = 120
+					}
+				}
+			}
+		}
+		if = {
+			limit = { has_character_flag = obj_demesne }
+			prestige = 25
+		}
+		set_character_flag = obj_demesne
+	}
+}
+
+obj_increase_demesne_12 = {
+	type = character
+	
+	potential = {
+		ai = no
+		demesne_size = 12
+		not = { demesne_size = 13 }
+	}
+	allow = {
+		is_adult = yes
+		not = { trait = incapable }
+		not = { over_max_demesne_size = 0 }
+	}
+	chance = {
+		factor = 0
+	}
+	success = {
+		demesne_size = 13
+	}
+	abort = {
+		or = {
+			trait = incapable
+			is_playable = no
+		}
+	}
+	abort_effect = {
+	}
+	effect = {
+		if = {
+			limit = { not = { has_character_flag = obj_demesne } }
+			change_stewardship = 1
+			if = {
+				limit = {
+					independent = no
+					in_revolt = no
+				}
+				liege = {
+					reverse_opinion = {
+						who = ROOT
+						modifier = opinion_happy
+						months = 120
+					}
+				}
+			}
+		}
+		if = {
+			limit = { has_character_flag = obj_demesne }
+			prestige = 25
+		}
+		set_character_flag = obj_demesne
+	}
+}

--- a/EMF/interface/EMF_objectives.gfx
+++ b/EMF/interface/EMF_objectives.gfx
@@ -83,6 +83,90 @@ spriteTypes = {
 		norefcount = yes
 		effectFile = "gfx/FX/buttonstate.lua"
 	}
+	spriteType = {
+		name = "GFX_obj_increase_demesne_1"
+		texturefile = "gfx/ambitions/obj_amass_wealth.tga" # FIXME: PLACEHOLDER ICON
+		noOfFrames = 1
+		norefcount = yes
+		effectFile = "gfx/FX/buttonstate.lua"
+	}
+	spriteType = {
+		name = "GFX_obj_increase_demesne_2"
+		texturefile = "gfx/ambitions/obj_amass_wealth.tga" # FIXME: PLACEHOLDER ICON
+		noOfFrames = 1
+		norefcount = yes
+		effectFile = "gfx/FX/buttonstate.lua"
+	}
+	spriteType = {
+		name = "GFX_obj_increase_demesne_3"
+		texturefile = "gfx/ambitions/obj_amass_wealth.tga" # FIXME: PLACEHOLDER ICON
+		noOfFrames = 1
+		norefcount = yes
+		effectFile = "gfx/FX/buttonstate.lua"
+	}
+	spriteType = {
+		name = "GFX_obj_increase_demesne_4"
+		texturefile = "gfx/ambitions/obj_amass_wealth.tga" # FIXME: PLACEHOLDER ICON
+		noOfFrames = 1
+		norefcount = yes
+		effectFile = "gfx/FX/buttonstate.lua"
+	}
+	spriteType = {
+		name = "GFX_obj_increase_demesne_5"
+		texturefile = "gfx/ambitions/obj_amass_wealth.tga" # FIXME: PLACEHOLDER ICON
+		noOfFrames = 1
+		norefcount = yes
+		effectFile = "gfx/FX/buttonstate.lua"
+	}
+	spriteType = {
+		name = "GFX_obj_increase_demesne_6"
+		texturefile = "gfx/ambitions/obj_amass_wealth.tga" # FIXME: PLACEHOLDER ICON
+		noOfFrames = 1
+		norefcount = yes
+		effectFile = "gfx/FX/buttonstate.lua"
+	}
+	spriteType = {
+		name = "GFX_obj_increase_demesne_7"
+		texturefile = "gfx/ambitions/obj_amass_wealth.tga" # FIXME: PLACEHOLDER ICON
+		noOfFrames = 1
+		norefcount = yes
+		effectFile = "gfx/FX/buttonstate.lua"
+	}
+	spriteType = {
+		name = "GFX_obj_increase_demesne_8"
+		texturefile = "gfx/ambitions/obj_amass_wealth.tga" # FIXME: PLACEHOLDER ICON
+		noOfFrames = 1
+		norefcount = yes
+		effectFile = "gfx/FX/buttonstate.lua"
+	}
+	spriteType = {
+		name = "GFX_obj_increase_demesne_9"
+		texturefile = "gfx/ambitions/obj_amass_wealth.tga" # FIXME: PLACEHOLDER ICON
+		noOfFrames = 1
+		norefcount = yes
+		effectFile = "gfx/FX/buttonstate.lua"
+	}
+	spriteType = {
+		name = "GFX_obj_increase_demesne_10"
+		texturefile = "gfx/ambitions/obj_amass_wealth.tga" # FIXME: PLACEHOLDER ICON
+		noOfFrames = 1
+		norefcount = yes
+		effectFile = "gfx/FX/buttonstate.lua"
+	}
+	spriteType = {
+		name = "GFX_obj_increase_demesne_11"
+		texturefile = "gfx/ambitions/obj_amass_wealth.tga" # FIXME: PLACEHOLDER ICON
+		noOfFrames = 1
+		norefcount = yes
+		effectFile = "gfx/FX/buttonstate.lua"
+	}
+	spriteType = {
+		name = "GFX_obj_increase_demesne_12"
+		texturefile = "gfx/ambitions/obj_amass_wealth.tga" # FIXME: PLACEHOLDER ICON
+		noOfFrames = 1
+		norefcount = yes
+		effectFile = "gfx/FX/buttonstate.lua"
+	}
 	# From PB
 	spriteType = {
 		name = "GFX_obj_convert_a_province"

--- a/EMF/localisation/emf_objectives.csv
+++ b/EMF/localisation/emf_objectives.csv
@@ -32,3 +32,27 @@ obj_fifteen_children_title;Have Fifteen Children;;;;;;;;;;;;;x
 obj_fifteen_children_desc;[This.GetTitledFirstName] wants a very large family and many children to carry on [This.GetHerHis] legacy.;;;;;;;;;;;;;x
 obj_twenty_children_title;Have Twenty Children;;;;;;;;;;;;;x
 obj_twenty_children_desc;[This.GetTitledFirstName] wants a huge large family and many-- so damn many-- children to carry on [This.GetHerHis] legacy.;;;;;;;;;;;;;x
+obj_increase_demesne_1_title;Increase Size of Demesne;;;;;;;;;;;;;x
+obj_increase_demesne_1_desc;[This.GetTitledFirstName] wishes to grow the size of [This.GetHerHis] demesne.;;;;;;;;;;;;;x
+obj_increase_demesne_2_title;Increase Size of Demesne;;;;;;;;;;;;;x
+obj_increase_demesne_2_desc;[This.GetTitledFirstName] wishes to grow the size of [This.GetHerHis] demesne.;;;;;;;;;;;;;x
+obj_increase_demesne_3_title;Increase Size of Demesne;;;;;;;;;;;;;x
+obj_increase_demesne_3_desc;[This.GetTitledFirstName] wishes to grow the size of [This.GetHerHis] demesne.;;;;;;;;;;;;;x
+obj_increase_demesne_4_title;Increase Size of Demesne;;;;;;;;;;;;;x
+obj_increase_demesne_4_desc;[This.GetTitledFirstName] wishes to grow the size of [This.GetHerHis] demesne.;;;;;;;;;;;;;x
+obj_increase_demesne_5_title;Increase Size of Demesne;;;;;;;;;;;;;x
+obj_increase_demesne_5_desc;[This.GetTitledFirstName] wishes to grow the size of [This.GetHerHis] demesne.;;;;;;;;;;;;;x
+obj_increase_demesne_6_title;Increase Size of Demesne;;;;;;;;;;;;;x
+obj_increase_demesne_6_desc;[This.GetTitledFirstName] wishes to grow the size of [This.GetHerHis] demesne.;;;;;;;;;;;;;x
+obj_increase_demesne_7_title;Increase Size of Demesne;;;;;;;;;;;;;x
+obj_increase_demesne_7_desc;[This.GetTitledFirstName] wishes to grow the size of [This.GetHerHis] demesne.;;;;;;;;;;;;;x
+obj_increase_demesne_8_title;Increase Size of Demesne;;;;;;;;;;;;;x
+obj_increase_demesne_8_desc;[This.GetTitledFirstName] wishes to grow the size of [This.GetHerHis] demesne.;;;;;;;;;;;;;x
+obj_increase_demesne_9_title;Increase Size of Demesne;;;;;;;;;;;;;x
+obj_increase_demesne_9_desc;[This.GetTitledFirstName] wishes to grow the size of [This.GetHerHis] demesne.;;;;;;;;;;;;;x
+obj_increase_demesne_10_title;Increase Size of Demesne;;;;;;;;;;;;;x
+obj_increase_demesne_10_desc;[This.GetTitledFirstName] wishes to grow the size of [This.GetHerHis] demesne.;;;;;;;;;;;;;x
+obj_increase_demesne_11_title;Increase Size of Demesne;;;;;;;;;;;;;x
+obj_increase_demesne_11_desc;[This.GetTitledFirstName] wishes to grow the size of [This.GetHerHis] demesne.;;;;;;;;;;;;;x
+obj_increase_demesne_12_title;Increase Size of Demesne;;;;;;;;;;;;;x
+obj_increase_demesne_12_desc;[This.GetTitledFirstName] wishes to grow the size of [This.GetHerHis] demesne.;;;;;;;;;;;;;x


### PR DESCRIPTION
@thefinestsieve They should presumably all use the same icon.  Currently, they're using the 'Amass Wealth' generic icon as a placeholder.

Added an 'Increase Size of Demesne' ambition for demesne sizes 1 through 12.  Player can repeat, but the AI cannot, and the AI can't access the top 3 tiers of the ambition.