### PR TITLE
Major revolt CB maintenance

### DIFF
--- a/EMF/common/cb_types/03_claim_on_liege.txt
+++ b/EMF/common/cb_types/03_claim_on_liege.txt
@@ -121,19 +121,12 @@ claim_on_liege = {
 	}
 	
 	on_add = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 	}
 	
 	on_success = {
-		hidden_tooltip = {
-			any_attacker = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_victory_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		any_attacker = {
 			limit = { character = ROOT }
@@ -257,8 +250,7 @@ claim_on_liege = {
 	}
 
 	on_fail = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -100
@@ -283,14 +275,8 @@ claim_on_liege = {
 	}
 
 	on_reverse_demand = {
-		hidden_tooltip = {
-			any_defender = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_defeat_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -150
@@ -325,9 +311,10 @@ claim_on_liege = {
 			}
 		}
 		end_war = invalid
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+	}
+
+	on_invalidation = {
+		emf_cb_dynlevy_effect = yes
 	}
 	
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/04_claim_on_liege_plot.txt
+++ b/EMF/common/cb_types/04_claim_on_liege_plot.txt
@@ -78,19 +78,12 @@ claim_on_liege_plot = {
 	}
 
 	on_add = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 	}
 	
 	on_success = {
-		hidden_tooltip = {
-			any_attacker = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_victory_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		any_attacker = {
 			limit = { character = ROOT }
@@ -174,8 +167,7 @@ claim_on_liege_plot = {
 	}
 
 	on_fail = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -100
@@ -199,14 +191,8 @@ claim_on_liege_plot = {
 	}
 
 	on_reverse_demand = {
-		hidden_tooltip = {
-			any_defender = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_defeat_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -200
@@ -239,9 +225,10 @@ claim_on_liege_plot = {
 			}
 		}
 		end_war = invalid
+	}
 
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+	on_invalidation = {
+		emf_cb_dynlevy_effect = yes
 	}
 	
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/06_other_claim_on_liege.txt
+++ b/EMF/common/cb_types/06_other_claim_on_liege.txt
@@ -31,8 +31,18 @@ other_claim_on_liege = {
 #	attacker_can_call_allies = no	
 	major_revolt = yes
 
+	can_use = {
+		FROMFROM = {
+			emf_cb_tribute_block_trigger = no
+		}
+	}
+
 	can_use_title = {
-		ROOT = { emf_cb_tribute_block_trigger = no }
+
+		FROM = {
+			has_landed_title = PREV
+		}
+
 		OR = {
 			ROOT = { is_female = no }
 			NOT = { has_law = agnatic_succession }
@@ -41,12 +51,6 @@ other_claim_on_liege = {
 				is_primary_holder_title = no
 			}
 			FROMFROM = { has_character_flag = faction_claimant_ultimatum_taken } # Faction war. Ignore claim strength.
-		}
-
-		OR = {
-			FROM = {
-				has_landed_title = PREV
-			}
 		}
 		
 		OR = { 
@@ -65,6 +69,7 @@ other_claim_on_liege = {
 				}
 			}
 		}
+
 		is_vice_royalty = no
 	}
 	
@@ -121,19 +126,12 @@ other_claim_on_liege = {
 	}
 
 	on_add = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { character_event = { id = emf_dynlevy.4 } }
+		emf_cb_dynlevy_other_effect = yes
 	}
 	
 	on_success = {
-		hidden_tooltip = {
-			any_attacker = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { character_event = { id = emf_dynlevy.4 } }
+		emf_cb_victory_effect = yes
+		emf_cb_dynlevy_other_effect = yes
 		
 		any_attacker = {
 			limit = { 
@@ -168,6 +166,26 @@ other_claim_on_liege = {
 			limit = { tier = count }
 			emf_cb_nomadic_province_effect = yes
 		}
+		
+		# In EMF, all title usurpations drop CA, so just show a tooltip and
+		# don't really do it here (or else we'd drop it twice).
+		if = {
+			limit = { has_law = crown_authority_1 }
+			tooltip = { add_law = crown_authority_0 }
+		}
+		if = {
+			limit = { has_law = crown_authority_2 }
+			tooltip = { add_law = crown_authority_1 }
+		}
+		if = {
+			limit = { has_law = crown_authority_3 }
+			tooltip = { add_law = crown_authority_2 }
+		}
+		if = {
+			limit = { has_law = crown_authority_4 }
+			tooltip = { add_law = crown_authority_3 }
+		}
+
 		FROM = {
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
 			
@@ -193,25 +211,6 @@ other_claim_on_liege = {
 					add_law = crown_authority_3
 				}
 			}
-		}
-		
-		# In EMF, all title usurpations drop CA, so just show a tooltip and
-		# don't really do it here (or else we'd drop it twice).
-		if = {
-			limit = { has_law = crown_authority_1 }
-			tooltip = { add_law = crown_authority_0 }
-		}
-		if = {
-			limit = { has_law = crown_authority_2 }
-			tooltip = { add_law = crown_authority_1 }
-		}
-		if = {
-			limit = { has_law = crown_authority_3 }
-			tooltip = { add_law = crown_authority_2 }
-		}
-		if = {
-			limit = { has_law = crown_authority_4 }
-			tooltip = { add_law = crown_authority_3 }
 		}
 		
 		if = {
@@ -331,8 +330,7 @@ other_claim_on_liege = {
 	}
 
 	on_fail = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { character_event = { id = emf_dynlevy.4 } }
+		emf_cb_dynlevy_other_effect = yes
 		
 		prestige = -100
 		
@@ -368,14 +366,8 @@ other_claim_on_liege = {
 	}
 
 	on_reverse_demand = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { character_event = { id = emf_dynlevy.4 } }
-		
-		hidden_tooltip = {
-			any_defender = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
+		emf_cb_defeat_effect = yes
+		emf_cb_dynlevy_other_effect = yes
 		
 		prestige = -200
 		
@@ -410,6 +402,10 @@ other_claim_on_liege = {
 		}
 		
 		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
+	}
+
+	on_invalidation = {
+		emf_cb_dynlevy_other_effect = yes
 	}
 	
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/08_change_seniority_succession_law.txt
+++ b/EMF/common/cb_types/08_change_seniority_succession_law.txt
@@ -69,19 +69,12 @@ change_seniority_succession_law = {
 	}
 	
 	on_add = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 	}
 	
 	on_success = {
-		hidden_tooltip = {
-			any_attacker = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_victory_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		FROM = {
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
@@ -127,8 +120,7 @@ change_seniority_succession_law = {
 	}
 
 	on_fail = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -100
@@ -156,14 +148,8 @@ change_seniority_succession_law = {
 	}
 
 	on_reverse_demand = {
-		hidden_tooltip = {
-			any_defender = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_defeat_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -200
@@ -192,6 +178,10 @@ change_seniority_succession_law = {
 		}
 		
 		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
+	}
+
+	on_invalidation = {
+		emf_cb_dynlevy_effect = yes
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/09_change_primogeniture_succession_law.txt
+++ b/EMF/common/cb_types/09_change_primogeniture_succession_law.txt
@@ -69,19 +69,12 @@ change_primogeniture_succession_law = {
 	}
 
 	on_add = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 	}
 	
 	on_success = {
-		hidden_tooltip = {
-			any_attacker = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_victory_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		FROM = {
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
@@ -128,8 +121,7 @@ change_primogeniture_succession_law = {
 	}
 
 	on_fail = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -100
@@ -158,14 +150,8 @@ change_primogeniture_succession_law = {
 	}
 
 	on_reverse_demand = {
-		hidden_tooltip = {
-			any_defender = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_defeat_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -200
@@ -194,6 +180,10 @@ change_primogeniture_succession_law = {
 		}
 		
 		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
+	}
+
+	on_invalidation = {
+		emf_cb_dynlevy_effect = yes
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/10_change_feudal_elective_succession_law.txt
+++ b/EMF/common/cb_types/10_change_feudal_elective_succession_law.txt
@@ -69,19 +69,12 @@ change_feudal_elective_succession_law = {
 	}
 	
 	on_add = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 	}
 	
 	on_success = {
-		hidden_tooltip = {
-			any_attacker = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_victory_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		FROM = {
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
@@ -126,8 +119,7 @@ change_feudal_elective_succession_law = {
 	}
 
 	on_fail = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -100
@@ -155,14 +147,8 @@ change_feudal_elective_succession_law = {
 	}
 	
 	on_reverse_demand = {
-		hidden_tooltip = {
-			any_defender = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_defeat_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -200
@@ -191,6 +177,10 @@ change_feudal_elective_succession_law = {
 		}
 		
 		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
+	}
+
+	on_invalidation = {
+		emf_cb_dynlevy_effect = yes
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/18_overthrow_ruler.txt
+++ b/EMF/common/cb_types/18_overthrow_ruler.txt
@@ -62,19 +62,12 @@ overthrow_ruler = {
 	}
 
 	on_add = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 	}
 	
 	on_success = {
-		hidden_tooltip = {
-			any_attacker = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_victory_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			primary_title = {
@@ -126,8 +119,7 @@ overthrow_ruler = {
 	}
 
 	on_fail = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -100
@@ -141,14 +133,8 @@ overthrow_ruler = {
 	}
 
 	on_reverse_demand = {
-		hidden_tooltip = {
-			any_defender = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_defeat_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -200
@@ -182,6 +168,10 @@ overthrow_ruler = {
 		}
 		
 		end_war = invalid
+	}
+
+	on_invalidation = {
+		emf_cb_dynlevy_effect = yes
 	}
 	
 	defender_ai_victory_worth = {

--- a/EMF/common/cb_types/20_change_gavelkind_succession_law.txt
+++ b/EMF/common/cb_types/20_change_gavelkind_succession_law.txt
@@ -69,19 +69,12 @@ change_gavelkind_succession_law = {
 	}
 	
 	on_add = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 	}
 	
 	on_success = {
-		hidden_tooltip = {
-			any_attacker = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_victory_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		FROM = {
 			hidden_tooltip = { disband_event_forces = faction_loyalists }
@@ -128,8 +121,7 @@ change_gavelkind_succession_law = {
 	}
 
 	on_fail = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -100
@@ -157,14 +149,8 @@ change_gavelkind_succession_law = {
 	}
 
 	on_reverse_demand = {
-		hidden_tooltip = {
-			any_defender = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_defeat_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -200
@@ -193,6 +179,10 @@ change_gavelkind_succession_law = {
 		}
 		
 		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
+	}
+
+	on_invalidation = {
+		emf_cb_dynlevy_effect = yes
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/22_lower_tribal_organization_law.txt
+++ b/EMF/common/cb_types/22_lower_tribal_organization_law.txt
@@ -33,11 +33,6 @@ lower_tribal_organization_law = {
 		}
 	}
 	
-	on_add = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
-	}
-	
 	can_use_title = {
 		holder_scope = { independent = yes }
 		OR = {
@@ -77,14 +72,14 @@ lower_tribal_organization_law = {
 			}
 		}
 	}
+	
+	on_add = {
+		emf_cb_dynlevy_effect = yes
+	}
 
 	on_success = {
-		hidden_tooltip = {
-			any_attacker = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } } # Adjust dynlevy laws due to realm fracture
+		emf_cb_victory_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			opinion = {
@@ -130,7 +125,7 @@ lower_tribal_organization_law = {
 	}
 
 	on_fail = {
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } } # Adjust dynlevy laws due to realm fracture
+		emf_cb_dynlevy_effect = yes
 		ROOT = {
 			prestige = -100
 		}
@@ -158,12 +153,8 @@ lower_tribal_organization_law = {
 	}
 
 	on_reverse_demand = {
-		hidden_tooltip = {
-			any_defender = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } } # Adjust dynlevy laws due to realm fracture
+		emf_cb_defeat_effect = yes
+		emf_cb_dynlevy_effect = yes
 		ROOT = {
 			prestige = -200
 			prisoner = FROM
@@ -191,6 +182,10 @@ lower_tribal_organization_law = {
 			}
 		}
 		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
+	}
+
+	on_invalidation = {
+		emf_cb_dynlevy_effect = yes
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/28_cb_faction_independence.txt
+++ b/EMF/common/cb_types/28_cb_faction_independence.txt
@@ -67,16 +67,11 @@ cb_faction_independence = {
 	}
 	
 	on_add = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 	}
 
 	on_success = {
-		hidden_tooltip = {
-			any_attacker = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
+		emf_cb_victory_effect = yes
 
 		if = {
 			limit = {
@@ -100,11 +95,8 @@ cb_faction_independence = {
 						limit = {
 							controls_religion = no
 							higher_tier_than = BARON
-							FROM = {
-								OR = { # If the old liege can use the subjugation CB, give no claims
-									NOT = { religion_group = pagan_group }
-									NOT = { culture_group = PREVPREV }
-								}
+							FROM = { # If the old liege can use the subjugation CB, give no claims
+								NOT = { religion_group = pagan_group }
 							}
 						}
 						add_weak_pressed_claim = FROM
@@ -112,9 +104,41 @@ cb_faction_independence = {
 				}
 			}		
 		}
+
+		if = {
+			limit = {
+				FROM = {
+					independent = no
+				}
+			}
+			any_attacker = {
+				limit = {
+					OR = {
+						vassal_of = FROM
+						liege_before_war = {
+							character = FROM
+						}
+					}
+				}
+				FROM = {
+					liege = {
+						set_defacto_vassal = PREVPREV
+					}
+				}
+				hidden_tooltip = {
+					prestige = 100
+					any_demesne_title = {
+						limit = {
+							controls_religion = no
+							higher_tier_than = BARON
+						}
+						add_weak_pressed_claim = FROM
+					}
+				}
+			}		
+		}
 		
-		# Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 		
 		any_attacker = {
 			limit = { character = ROOT }
@@ -157,8 +181,7 @@ cb_faction_independence = {
 	}
 
 	on_fail = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 
 		ROOT = {
 			prestige = -50
@@ -192,14 +215,8 @@ cb_faction_independence = {
 	}
 
 	on_reverse_demand = {
-		hidden_tooltip = {
-			any_defender = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_defeat_effect = yes
+		emf_cb_dynlevy_effect = yes
 
 		ROOT = {
 			prestige = -100
@@ -252,12 +269,10 @@ cb_faction_independence = {
 		}
 
 		end_war = invalid
-		
-		# EMF: Adjust dynlevy laws according to new de facto realms
-		hidden_tooltip = {
-			ROOT = { character_event = { id = emf_dynlevy.20 } }
-			FROM = { character_event = { id = emf_dynlevy.20 } }
-		}
+	}
+
+	on_invalidation = {
+		emf_cb_dynlevy_effect = yes
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/49_cb_install_antiking.txt
+++ b/EMF/common/cb_types/49_cb_install_antiking.txt
@@ -41,11 +41,6 @@ cb_install_antiking = {
 		}
 	}
 	
-	on_add = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
-	}
-	
 	is_valid = {
 		NOT = { 
 			holder_scope = { 
@@ -75,16 +70,13 @@ cb_install_antiking = {
 		}
 	}
 	
+	on_add = {
+		emf_cb_dynlevy_effect = yes
+	}
+	
 	on_success = {
-		hidden_tooltip = {
-			any_attacker = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-				add_character_modifier = { name = emf_holy_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_holy_victory_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		any_attacker = {
 			limit = { character = ROOT }
@@ -155,8 +147,7 @@ cb_install_antiking = {
 	}
 
 	on_fail = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = { 
 			piety = -250
@@ -170,10 +161,8 @@ cb_install_antiking = {
 	}
 
 	on_reverse_demand = {
-		hidden_tooltip = { FROM = { add_character_modifier = { name = emf_victory_timer duration = 7 hidden = yes } } }
-		
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_defeat_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			transfer_scaled_wealth = {
@@ -190,6 +179,10 @@ cb_install_antiking = {
 			piety = 500
 			prestige = 250
 		}
+	}
+
+	on_invalidation = {
+		emf_cb_dynlevy_effect = yes
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/57_cb_install_khan.txt
+++ b/EMF/common/cb_types/57_cb_install_khan.txt
@@ -66,16 +66,11 @@ cb_install_khan = {
 	}
 
 	on_add = {
-		# EMF: Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 	}
 	
 	on_success = {
-		hidden_tooltip = {
-			any_attacker = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
+		emf_cb_victory_effect = yes
 		
 		FROM = {
 			any_demesne_title = {
@@ -88,8 +83,7 @@ cb_install_khan = {
 			}
 		}
 		
-		# Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 		
 		any_attacker = {
 			limit = { character = ROOT }
@@ -102,8 +96,7 @@ cb_install_khan = {
 	}
 
 	on_fail = {
-		# Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -100
@@ -111,14 +104,8 @@ cb_install_khan = {
 	}
 
 	on_reverse_demand = {
-		hidden_tooltip = {
-			any_defender = {
-				add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-			}
-		}
-		
-		# Adjust dynlevy laws due to realm fracture
-		hidden_tooltip = { ROOT = { character_event = { id = emf_dynlevy.4 } } }
+		emf_cb_defeat_effect = yes
+		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
 			prestige = -200
@@ -152,6 +139,10 @@ cb_install_khan = {
 		}
 		
 		end_war = invalid
+	}
+
+	on_invalidation = {
+		emf_cb_dynlevy_effect = yes
 	}
 
 	defender_ai_victory_worth = {

--- a/EMF/common/scripted_effects/emf_cb_effects.txt
+++ b/EMF/common/scripted_effects/emf_cb_effects.txt
@@ -109,52 +109,78 @@ emf_cb_nomadic_province_effect = {
 	}
 }
 
+
 emf_cb_victory_effect = {
-	any_attacker = {
-		add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-	}
-	any_attacker = {
-		limit = { has_ambition = obj_win_war }
-		ambition_succeeds = yes
+	hidden_tooltip = {
+		any_attacker = {
+			add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
+		}
+		any_attacker = {
+			limit = { has_ambition = obj_win_war }
+			ambition_succeeds = yes
+		}
 	}
 }
 
 emf_cb_defeat_effect = {
-	any_defender = {
-		add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-	}
-	any_defender = {
-		limit = { has_ambition = obj_win_war }
-		ambition_succeeds = yes
+	hidden_tooltip = {
+		any_defender = {
+			add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
+		}
+		any_defender = {
+			limit = { has_ambition = obj_win_war }
+			ambition_succeeds = yes
+		}
 	}
 }
 
 emf_cb_holy_victory_effect = {
-	any_attacker = {
-		add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-		add_character_modifier = { name = emf_holy_victory_timer duration = 1 hidden = yes }
-	}
-	any_attacker = {
-		limit = { has_ambition = obj_win_war }
-		ambition_succeeds = yes
-	}
-	any_attacker = {
-		limit = { has_ambition = obj_win_holy_war }
-		ambition_succeeds = yes
+	hidden_tooltip = {
+		any_attacker = {
+			add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
+			add_character_modifier = { name = emf_holy_victory_timer duration = 1 hidden = yes }
+		}
+		any_attacker = {
+			limit = { has_ambition = obj_win_war }
+			ambition_succeeds = yes
+		}
+		any_attacker = {
+			limit = { has_ambition = obj_win_holy_war }
+			ambition_succeeds = yes
+		}
 	}
 }
 
 emf_cb_holy_defeat_effect = {
-	any_defender = {
-		add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
-		add_character_modifier = { name = emf_holy_victory_timer duration = 1 hidden = yes }
+	hidden_tooltip = {
+		any_defender = {
+			add_character_modifier = { name = emf_victory_timer duration = 1 hidden = yes }
+			add_character_modifier = { name = emf_holy_victory_timer duration = 1 hidden = yes }
+		}
+		any_defender = {
+			limit = { has_ambition = obj_win_war }
+			ambition_succeeds = yes
+		}
+		any_defender = {
+			limit = { has_ambition = obj_win_holy_war }
+			ambition_succeeds = yes
+		}
 	}
-	any_defender = {
-		limit = { has_ambition = obj_win_war }
-		ambition_succeeds = yes
+}
+
+
+# regular major_revolt CBs
+emf_cb_dynlevy_effect = {
+	hidden_tooltip = {
+		ROOT = { character_event = { id = emf_dynlevy.20 } }
+		FROM = { character_event = { id = emf_dynlevy.20 } }
 	}
-	any_defender = {
-		limit = { has_ambition = obj_win_holy_war }
-		ambition_succeeds = yes
+}
+
+# 3rd-party CBs: assumes enclosing scope is attacker
+emf_cb_dynlevy_other_effect = {
+	hidden_tooltip = {
+		FROM = { character_event = { id = emf_dynlevy.20 } }
+		character_event = { id = emf_dynlevy.20 }
 	}
 }

--- a/EMF/events/emf_dynlevy.txt
+++ b/EMF/events/emf_dynlevy.txt
@@ -104,25 +104,3 @@ character_event = {
 	
 	option = { name = OK }
 }
-
-# emf_dynlevy.4
-# CB supplement to adjust both the dynlevy laws associated with ROOT and FROMFROM
-# It is called on the attacker (thus FROM in the CB becomes FROMFROM here)
-#
-# This is intended for major_revolt CBs, for application upon revolt start and end.
-# Note that we adjust the title laws immediately, unlike the title transfer listeners.
-character_event = {
-	id = emf_dynlevy.4
-	desc = HIDE_EVENT
-	hide_window = yes
-	is_triggered_only = yes
-	
-	immediate = {
-		FROMFROM = {
-			character_event = { id = emf_dynlevy.20 }
-		}
-		character_event = { id = emf_dynlevy.20 }
-	}
-	
-	option = { name = OK }
-}

--- a/EMF/localisation/emf_cb.csv
+++ b/EMF/localisation/emf_cb.csv
@@ -52,6 +52,7 @@ emf_region_ir_tier_3;Imperial Reconquest Tier 3 (Italy, Levant, and Eastern/Cent
 emf_region_ir_tier_4;Imperial Reconquest Tier 4 (Northwestern Africa and Iberia);;;;;;;;;;;;;x
 emf_region_ir_tier_5;Imperial Reconquest Tier 5 (France);;;;;;;;;;;;;x
 emf_region_ir_tier_6;Imperial Reconquest Tier 6 (England, Wales, and Germany);;;;;;;;;;;;;x
+emf_region_manifest_destiny;Manifest Destiny (Seljuk/Timurid);;;;;;;;;;;;;x
 #### TOOLTIPS;;;;;;;;;;;;;;x
 emf_ctt_baqt_unaffected;Unaffected by Baqt Treaty\n;;;;No afectado por la Baqt\n;;;;;;;;;x
 emf_ctt_no_holy_war_cooldown;§Y[This.GetTitledFirstName]§! has no holy war CB cooldown in effect, or cooldowns have been disabled.\n;;;;;;;;;;;;;x


### PR DESCRIPTION
- Fixed dynlevy helper (readjust dynlevy laws due to realm fracture) for 3rd-party major revolt CBs (other_claim_on_liege)
- Rolled dynlevy helpers into scripted_effects and applied them everywhere
- Added `on_invalidation` handlers for fixing dynlevy state immediately upon revolt invalidation
- Added support in the independence faction CB for non-independent lieges (faction will need to be adjusted to support that-- finally!)
- Gradual move to scripted effects for defeat/victory helpers (re: war ambitions)