### PR TITLE
Next iteration on CB logging

### DIFF
--- a/EMF/common/cb_types/01_claim.txt
+++ b/EMF/common/cb_types/01_claim.txt
@@ -80,7 +80,7 @@ claim = {
 	}
 
 	on_add_title = {
-		log = "CB(claim): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
@@ -88,7 +88,7 @@ claim = {
 	}
 
 	on_success_title = {
-		log = "CB(claim): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		if = {
 			limit = { tier = count }
 			emf_cb_nomadic_province_effect = yes
@@ -135,7 +135,7 @@ claim = {
 	}
 
 	on_fail_title = {
-		log = "CB(claim): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		ROOT = {
 			prestige = -100
 			hidden_tooltip = {
@@ -179,7 +179,7 @@ claim = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(claim): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		ROOT = {
 			remove_claim = PREV
 			hidden_tooltip = {
@@ -205,7 +205,7 @@ claim = {
 	}
 
 	on_invalidation = {
-		log = "CB(claim): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/02_other_claim.txt
+++ b/EMF/common/cb_types/02_other_claim.txt
@@ -151,11 +151,11 @@ other_claim = {
 	}
 
 	on_add = {
-		log = "CB(other_claim): START: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_claim): START: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 	}
 
 	on_success = {
-		log = "CB(other_claim): VICTORY: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_claim): VICTORY: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 		emf_cb_victory_other_effect = yes
 		hidden_tooltip = {
 			ROOT = {
@@ -410,7 +410,7 @@ other_claim = {
 	}
 
 	on_fail = {
-		log = "CB(other_claim): WHITEPEACE: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_claim): WHITEPEACE: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 	}
 
 	on_fail_title = {
@@ -434,7 +434,7 @@ other_claim = {
 	}
 
 	on_reverse_demand = {
-		log = "CB(other_claim): DEFEAT: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_claim): DEFEAT: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 		emf_cb_defeat_other_effect = yes
 		prestige = -150
 		transfer_scaled_wealth = {
@@ -462,7 +462,7 @@ other_claim = {
 	}
 
 	on_invalidation = {
-		log = "CB(other_claim): INVALIDATED: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_claim): INVALIDATED: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/03_claim_on_liege.txt
+++ b/EMF/common/cb_types/03_claim_on_liege.txt
@@ -128,7 +128,7 @@ claim_on_liege = {
 	}
 
 	on_add_title = {
-		log = "CB(claim_on_liege): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_liege): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	on_success = {
@@ -152,7 +152,7 @@ claim_on_liege = {
 	}
 	
 	on_success_title = {
-		log = "CB(claim_on_liege): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_liege): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		if = {
 			limit = { tier = count }
 			emf_cb_nomadic_province_effect = yes
@@ -283,7 +283,7 @@ claim_on_liege = {
 	}
 
 	on_fail_title = {
-		log = "CB(claim_on_liege): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_liege): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -315,7 +315,7 @@ claim_on_liege = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(claim_on_liege): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_liege): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	on_attacker_leader_death = {
@@ -330,7 +330,7 @@ claim_on_liege = {
 	}
 
 	on_invalidation = {
-		log = "CB(claim_on_liege): INVALIDATED: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_liege): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_dynlevy_effect = yes
 	}
 	

--- a/EMF/common/cb_types/04_claim_on_liege_plot.txt
+++ b/EMF/common/cb_types/04_claim_on_liege_plot.txt
@@ -85,7 +85,7 @@ claim_on_liege_plot = {
 	}
 
 	on_add_title = {
-		log = "CB(claim_on_liege_plot): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_liege_plot): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	on_success = {
@@ -109,7 +109,7 @@ claim_on_liege_plot = {
 	}
 	
 	on_success_title = {
-		log = "CB(claim_on_liege_plot): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_liege_plot): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		if = {
 			limit = { tier = count }
 			emf_cb_nomadic_province_effect = yes
@@ -199,7 +199,7 @@ claim_on_liege_plot = {
 	}
 
 	on_fail_title = {
-		log = "CB(claim_on_liege_plot): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_liege_plot): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -229,7 +229,7 @@ claim_on_liege_plot = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(claim_on_liege_plot): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_liege_plot): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	on_attacker_leader_death = {
@@ -244,7 +244,7 @@ claim_on_liege_plot = {
 	}
 
 	on_invalidation = {
-		log = "CB(claim_on_liege_plot): INVALIDATED: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_liege_plot): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 
 		emf_cb_dynlevy_effect = yes
 	}

--- a/EMF/common/cb_types/05_claim_on_vassal_plot.txt
+++ b/EMF/common/cb_types/05_claim_on_vassal_plot.txt
@@ -59,7 +59,7 @@ claim_on_vassal_plot = {
 	}
 
 	on_add_title = {
-		log = "CB(claim_on_vassal_plot): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_vassal_plot): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
@@ -70,7 +70,7 @@ claim_on_vassal_plot = {
 	}
 	
 	on_success_title = {
-		log = "CB(claim_on_vassal_plot): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_vassal_plot): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		if = {
 			limit = { tier = count }
 			emf_cb_nomadic_province_effect = yes
@@ -95,7 +95,7 @@ claim_on_vassal_plot = {
 	}
 
 	on_fail_title = {
-		log = "CB(claim_on_vassal_plot): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_vassal_plot): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -115,11 +115,11 @@ claim_on_vassal_plot = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(claim_on_vassal_plot): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_vassal_plot): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_invalidation = {
-		log = "CB(claim_on_vassal_plot): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_on_vassal_plot): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	on_attacker_leader_death = {

--- a/EMF/common/cb_types/06_other_claim_on_liege.txt
+++ b/EMF/common/cb_types/06_other_claim_on_liege.txt
@@ -126,11 +126,11 @@ other_claim_on_liege = {
 	}
 
 	on_add = {
-		log = "CB(other_claim_on_liege): START: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_claim_on_liege): START: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 	}
 	
 	on_success = {
-		log = "CB(other_claim_on_liege): VICTORY: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_claim_on_liege): VICTORY: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 		emf_cb_victory_other_effect = yes
 		emf_cb_dynlevy_other_effect = yes
 		
@@ -331,7 +331,7 @@ other_claim_on_liege = {
 	}
 
 	on_fail = {
-		log = "CB(other_claim_on_liege): WHITEPEACE: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_claim_on_liege): WHITEPEACE: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 		emf_cb_dynlevy_other_effect = yes
 		
 		prestige = -100
@@ -368,7 +368,7 @@ other_claim_on_liege = {
 	}
 
 	on_reverse_demand = {
-		log = "CB(other_claim_on_liege): DEFEAT: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_claim_on_liege): DEFEAT: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 		emf_cb_defeat_other_effect = yes
 		emf_cb_dynlevy_other_effect = yes
 		
@@ -408,7 +408,7 @@ other_claim_on_liege = {
 	}
 
 	on_invalidation = {
-		log = "CB(other_claim_on_liege): INVALIDATED: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_claim_on_liege): INVALIDATED: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 		emf_cb_dynlevy_other_effect = yes
 	}
 	

--- a/EMF/common/cb_types/07_claim_all.txt
+++ b/EMF/common/cb_types/07_claim_all.txt
@@ -53,7 +53,7 @@ claim_all = {
 	}
 
 	on_add = {
-		log = "CB(claim_all): START: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_all): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		ROOT = {
 			any_claim = {
 				limit = {
@@ -72,7 +72,7 @@ claim_all = {
 	}
 
 	on_success = {
-		log = "CB(claim_all): VICTORY: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_all): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_victory_effect = yes
 		ROOT = {
 			any_claim = {
@@ -125,7 +125,7 @@ claim_all = {
 	}
 
 	on_fail = {
-		log = "CB(claim_all): WHITEPEACE: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_all): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		ROOT = {
 			prestige = -150
 		}
@@ -140,7 +140,7 @@ claim_all = {
 	}
 
 	on_reverse_demand = {
-		log = "CB(claim_all): DEFEAT: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_all): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_defeat_effect = yes
 		ROOT = {			
 			prestige = -200
@@ -187,7 +187,7 @@ claim_all = {
 	}
 
 	on_invalidation = {
-		log = "CB(claim_all): INVALIDATED: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(claim_all): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/11_invasion.txt
+++ b/EMF/common/cb_types/11_invasion.txt
@@ -62,7 +62,7 @@ invasion = {
 	}
 
 	on_add_title = {
-		log = "CB(invasion): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(invasion): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
@@ -122,7 +122,7 @@ invasion = {
 	}
 
 	on_success_title = {
-		log = "CB(invasion): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(invasion): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_nomadic_province_effect = yes
 		
 		custom_tooltip = {
@@ -167,7 +167,7 @@ invasion = {
 	}
 
 	on_fail_title = {
-		log = "CB(invasion): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(invasion): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -206,14 +206,14 @@ invasion = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(invasion): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(invasion): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		ROOT = {
 			remove_claim = PREV
 		}
 	}
 
 	on_invalidation = {
-		log = "CB(invasion): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(invasion): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_attacker_leader_death = {

--- a/EMF/common/cb_types/12_tribal_invasion.txt
+++ b/EMF/common/cb_types/12_tribal_invasion.txt
@@ -197,7 +197,7 @@ tribal_invasion = {
 	}
 
 	on_add_title = {
-		log = "CB(tribal_invasion): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(tribal_invasion): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	on_success = {
@@ -238,7 +238,7 @@ tribal_invasion = {
 	}
 	
 	on_success_title = {
-		log = "CB(tribal_invasion): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(tribal_invasion): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_nomadic_province_effect = yes
 		
 		custom_tooltip = {
@@ -321,7 +321,7 @@ tribal_invasion = {
 	}
 
 	on_fail_title = {
-		log = "CB(tribal_invasion): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(tribal_invasion): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -374,11 +374,11 @@ tribal_invasion = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(tribal_invasion): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(tribal_invasion): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_invalidation = {
-		log = "CB(tribal_invasion): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(tribal_invasion): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/13_crusade.txt
+++ b/EMF/common/cb_types/13_crusade.txt
@@ -187,7 +187,7 @@ crusade = {
 	}
 
 	on_add_title = {
-		log = "CB(crusade): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(crusade): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
@@ -200,7 +200,7 @@ crusade = {
 	}
 
 	on_success_title = {
-		log = "CB(crusade): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(crusade): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_nomadic_province_effect = yes
 		
 		# Vanilla version
@@ -570,7 +570,7 @@ crusade = {
 	}
 
 	on_fail_title = {
-		log = "CB(crusade): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(crusade): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -651,11 +651,11 @@ crusade = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(crusade): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(crusade): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_invalidation = {
-		log = "CB(crusade): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(crusade): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/14_religious.txt
+++ b/EMF/common/cb_types/14_religious.txt
@@ -338,7 +338,7 @@ religious = {
 	}
 	
 	on_add_title = {
-		log = "CB(religious): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(religious): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		ROOT = {
 			if = {
 				limit = {
@@ -418,7 +418,7 @@ religious = {
 	}
 
 	on_success_title = {
-		log = "CB(religious): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(religious): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_nomadic_province_effect = yes
 		
 		custom_tooltip = {
@@ -445,7 +445,7 @@ religious = {
 	}
 
 	on_fail_title = {
-		log = "CB(religious): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(religious): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -497,11 +497,11 @@ religious = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(religious): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(religious): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_invalidation = {
-		log = "CB(religious): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(religious): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/15_excommunicated_ruler.txt
+++ b/EMF/common/cb_types/15_excommunicated_ruler.txt
@@ -56,11 +56,11 @@ excommunicated_ruler = {
 	}
 
 	on_add = {
-		log = "CB(excommunicated_ruler): START: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(excommunicated_ruler): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
-		log = "CB(excommunicated_ruler): VICTORY: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(excommunicated_ruler): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_holy_victory_effect = yes
 		ROOT = {
 			if = {
@@ -144,7 +144,7 @@ excommunicated_ruler = {
 	}
 
 	on_fail = {
-		log = "CB(excommunicated_ruler): WHITEPEACE: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(excommunicated_ruler): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		ROOT = {
 			piety = -50
 			prestige = -100
@@ -152,7 +152,7 @@ excommunicated_ruler = {
 	}
 
 	on_reverse_demand = {
-		log = "CB(excommunicated_ruler): DEFEAT: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(excommunicated_ruler): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_holy_defeat_effect = yes
 		ROOT = {
 			piety = -100
@@ -168,7 +168,7 @@ excommunicated_ruler = {
 	}
 
 	on_invalidation = {
-		log = "CB(excommunicated_ruler): INVALIDATED: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(excommunicated_ruler): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 

--- a/EMF/common/cb_types/16_bid_for_independence.txt
+++ b/EMF/common/cb_types/16_bid_for_independence.txt
@@ -128,11 +128,11 @@ bid_for_independence = {
 	}
 
 	on_add = {
-		log = "CB(bid_for_independence): START: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(bid_for_independence): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
-		log = "CB(bid_for_independence): VICTORY: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(bid_for_independence): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_victory_effect = yes
 	
 		if = {
@@ -221,7 +221,7 @@ bid_for_independence = {
 	}
 
 	on_fail = {
-		log = "CB(bid_for_independence): WHITEPEACE: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(bid_for_independence): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		ROOT = {
 			prestige = -50
 		}
@@ -236,7 +236,7 @@ bid_for_independence = {
 	}
 
 	on_reverse_demand = {
-		log = "CB(bid_for_independence): DEFEAT: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(bid_for_independence): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			prestige = -100
@@ -268,7 +268,7 @@ bid_for_independence = {
 	}
 
 	on_invalidation = {
-		log = "CB(bid_for_independence): INVALIDATED: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(bid_for_independence): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/18_overthrow_ruler.txt
+++ b/EMF/common/cb_types/18_overthrow_ruler.txt
@@ -62,12 +62,12 @@ overthrow_ruler = {
 	}
 
 	on_add = {
-		log = "CB(overthrow_ruler): START: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(overthrow_ruler): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_dynlevy_effect = yes
 	}
 	
 	on_success = {
-		log = "CB(overthrow_ruler): VICTORY: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(overthrow_ruler): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_victory_effect = yes
 		emf_cb_dynlevy_effect = yes
 		
@@ -121,7 +121,7 @@ overthrow_ruler = {
 	}
 
 	on_fail = {
-		log = "CB(overthrow_ruler): WHITEPEACE: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(overthrow_ruler): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
@@ -136,7 +136,7 @@ overthrow_ruler = {
 	}
 
 	on_reverse_demand = {
-		log = "CB(overthrow_ruler): DEFEAT: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(overthrow_ruler): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_defeat_effect = yes
 		emf_cb_dynlevy_effect = yes
 		
@@ -155,7 +155,7 @@ overthrow_ruler = {
 	}
 
 	on_invalidation = {
-		log = "CB(overthrow_ruler): INVALIDATED: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(overthrow_ruler): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_dynlevy_effect = yes
 	}
 

--- a/EMF/common/cb_types/19_overthrow_ruler_no_calls.txt
+++ b/EMF/common/cb_types/19_overthrow_ruler_no_calls.txt
@@ -62,11 +62,11 @@ overthrow_ruler_no_calls = {
 	}
 
 	on_add = {
-		log = "CB(overthrow_ruler_no_calls): START: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(overthrow_ruler_no_calls): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
-		log = "CB(overthrow_ruler_no_calls): VICTORY: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(overthrow_ruler_no_calls): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_victory_effect = yes
 		ROOT = {
 			prestige = 200
@@ -106,7 +106,7 @@ overthrow_ruler_no_calls = {
 	}
 
 	on_fail = {
-		log = "CB(overthrow_ruler_no_calls): WHITEPEACE: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(overthrow_ruler_no_calls): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		ROOT = {
 			prestige = -100
 		}
@@ -121,7 +121,7 @@ overthrow_ruler_no_calls = {
 	}
 
 	on_reverse_demand = {
-		log = "CB(overthrow_ruler_no_calls): DEFEAT: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(overthrow_ruler_no_calls): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			prestige = -200
@@ -133,7 +133,7 @@ overthrow_ruler_no_calls = {
 	}
 
 	on_invalidation = {
-		log = "CB(overthrow_ruler_no_calls): INVALIDATED: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(overthrow_ruler_no_calls): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/20_change_gavelkind_succession_law.txt
+++ b/EMF/common/cb_types/20_change_gavelkind_succession_law.txt
@@ -28,162 +28,17 @@ change_gavelkind_succession_law = {
 	major_revolt = yes
 	
 	can_use = {
-		ROOT = {
-			vassal_of = FROM	
-		}
+		always = no
 	}
 	
 	is_valid = {
-		FROM = {
-			in_revolt = no
-			liege_before_war = {
-				in_revolt = no
-				liege_before_war = {
-					in_revolt = no
-				}
-			}
-		}
-		ROOT = {
-			OR = {
-				liege = {
-					character = PREV # either independent
-				}
-				liege = { 
-					FROM = { 
-						is_liege_or_above = PREV # or have shared liege
-					}
-				}
-			}
-		}
+		always = no
 	}
 
-	is_valid_title = {
-		NOT = {
-			has_law = succ_gavelkind
-		}
-		OR = {
-			tier = emperor
-			tier = king
-			is_primary_holder_title = yes
-		}
-	}
-	
-	on_add = {
-		emf_cb_dynlevy_effect = yes
-	}
-	
 	on_success = {
-		emf_cb_victory_effect = yes
-		emf_cb_dynlevy_effect = yes
-		
-		FROM = {
-			pf_tradition_minus4_effect = yes
-			hidden_tooltip = { disband_event_forces = faction_loyalists }
-			
-			any_demesne_title = {
-				limit = { higher_tier_than = duke }
-				if = {
-					limit = { has_law = crown_authority_1 }
-					add_law = crown_authority_0
-				}
-				if = {
-					limit = { has_law = crown_authority_2 }
-					add_law = crown_authority_1
-				}
-				if = {
-					limit = { has_law = crown_authority_3 }
-					add_law = crown_authority_2
-				}
-				if = {
-					limit = { has_law = crown_authority_4 }
-					add_law = crown_authority_3
-				}
-			}
-		}
-		
-		any_attacker = {
-			limit = { character = ROOT }
-			participation_scaled_prestige = 100
-			hidden_tooltip = {
-				disband_event_forces = faction_revolters
-			}
-		}
-		any_attacker = {
-			limit = { NOT = { character = ROOT } }
-			hidden_tooltip = {
-				participation_scaled_prestige = 100 
-				disband_event_forces = faction_revolters
-			}
-		}
-	}
-
-	on_success_title = {
-		succession_w_cooldown = gavelkind
-	}
-
-	on_fail = {
-		emf_cb_dynlevy_effect = yes
-		
-		ROOT = {
-			prestige = -100
-		}
-		any_defender = {
-			limit = { character = FROM }
-			participation_scaled_prestige = 50
-		}
-		any_defender = {
-			limit = { NOT = { character = FROM } }
-			hidden_tooltip = { participation_scaled_prestige = 50 }
-		}
-		
-		hidden_tooltip = {
-			any_attacker = {
-				disband_event_forces = faction_revolters
-				add_character_modifier = {
-					name = faction_succ_gavelkind_ultimatum_timer
-					hidden = yes
-					duration = 3650
-				}
-			}
-		}
-		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
 	}
 
 	on_reverse_demand = {
-		emf_cb_defeat_effect = yes
-		emf_cb_dynlevy_effect = yes
-		FROM = { pf_tradition_plus4_effect = yes }
-		ROOT = {
-			prestige = -200
-			prisoner = FROM
-		}
-		any_defender = {
-			limit = { character = FROM }
-			participation_scaled_prestige = 100
-		}
-		any_defender = {
-			limit = { NOT = { character = FROM } }
-			hidden_tooltip = { participation_scaled_prestige = 100 }
-		}
-		
-		hidden_tooltip = {
-			any_attacker = {
-				limit = { liege = { character = FROM } }
-				prisoner = FROM
-				disband_event_forces = faction_revolters
-				add_character_modifier = {
-					name = faction_succ_gavelkind_ultimatum_timer
-					hidden = yes
-					duration = 3650
-				}
-			}
-		}
-		
-		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
-	}
-
-	on_invalidation = {
-		emf_cb_dynlevy_effect = yes
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/21_lower_crown_authority_law.txt
+++ b/EMF/common/cb_types/21_lower_crown_authority_law.txt
@@ -28,157 +28,20 @@ lower_crown_authority_law = {
 	major_revolt = yes
 	
 	can_use = {
-		FROM = {
-			higher_tier_than = duke
-		}
-		ROOT = {
-			vassal_of = FROM
-		}
-	}
-	
-	can_use_title = {
-		is_primary_holder_title = yes
-	}
-	
-	is_valid = {
-		FROM = {
-			in_revolt = no
-			liege_before_war = {
-				in_revolt = no
-				liege_before_war = {
-					in_revolt = no
-				}
-			}
-		}
-		ROOT = {
-			OR = {
-				liege = {
-					character = PREV # either independent
-				}
-				liege = { 
-					FROM = { 
-						is_liege_or_above = PREV # or have shared liege
-					}
-				}
-			}
-		}
+		always = no
 	}
 
-	on_add = {
-		emf_cb_dynlevy_effect = yes
+	is_valid = {
+		always = no
 	}
 
 	on_success = {
-		emf_cb_victory_effect = yes
-		emf_cb_dynlevy_effect = yes
-		ROOT = {
-			opinion = {
-				modifier = opinion_lowered_crown_authority
-				who = FROM
-				months = 12
-			}
-		}
-		any_attacker = {
-			limit = { character = ROOT }
-			participation_scaled_prestige = 100
-			hidden_tooltip = {
-				disband_event_forces = faction_revolters
-			}
-		}
-		any_attacker = {
-			limit = { NOT = { character = ROOT } }
-			hidden_tooltip = { participation_scaled_prestige = 100 }
-			hidden_tooltip = {
-				disband_event_forces = faction_revolters
-			}
-		}
-		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
-		
-		FROM = {
-			any_demesne_title = {
-				limit = { higher_tier_than = duke }
-				if = {
-					limit = { has_law = crown_authority_1 }
-					add_law = crown_authority_0
-				}
-				if = {
-					limit = { has_law = crown_authority_2 }
-					add_law = crown_authority_1
-				}
-				if = {
-					limit = { has_law = crown_authority_3 }
-					add_law = crown_authority_2
-				}
-				if = {
-					limit = { has_law = crown_authority_4 }
-					add_law = crown_authority_3
-				}
-			}
-		}
 	}
 
 	on_fail = {
-		emf_cb_dynlevy_effect = yes
-		ROOT = {
-			prestige = -100
-		}
-		
-		any_defender = {
-			limit = { character = FROM }
-			participation_scaled_prestige = 50
-		}
-		any_defender = {
-			limit = { NOT = { character = FROM } }
-			hidden_tooltip = { participation_scaled_prestige = 50 }
-		}
-		
-		hidden_tooltip = {
-			any_attacker = {
-				disband_event_forces = faction_revolters
-				add_character_modifier = {
-					name = faction_lower_CA_ultimatum_timer
-					hidden = yes
-					duration = 3650
-				}
-			}
-		}
-		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
 	}
 
 	on_reverse_demand = {
-		emf_cb_defeat_effect = yes
-		emf_cb_dynlevy_effect = yes
-		ROOT = {
-			prestige = -200
-			prisoner = FROM
-		}
-		
-		any_defender = {
-			limit = { character = FROM }
-			participation_scaled_prestige = 100
-		}
-		any_defender = {
-			limit = { NOT = { character = FROM } }
-			hidden_tooltip = { participation_scaled_prestige = 100 }
-		}
-		
-		hidden_tooltip = {
-			any_attacker = {
-				limit = { liege = { character = FROM } }
-				prisoner = FROM
-				disband_event_forces = faction_revolters
-				add_character_modifier = {
-					name = faction_lower_CA_ultimatum_timer
-					hidden = yes
-					duration = 3650
-				}
-			}
-		}
-		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
-	}
-
-	on_invalidation = {
-		emf_cb_dynlevy_effect = yes
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/22_lower_tribal_organization_law.txt
+++ b/EMF/common/cb_types/22_lower_tribal_organization_law.txt
@@ -25,167 +25,25 @@ lower_tribal_organization_law = {
 	truce_days = 3650
 	can_call_allies = no
 	can_ask_to_join_war = no
-	major_revolt = yes
+	#major_revolt = yes
+
+	is_permanent = no
 	
 	can_use = {
-		ROOT = {
-			vassal_of = FROM
-		}
-	}
-	
-	can_use_title = {
-		holder_scope = { independent = yes }
-		OR = {
-			tier = duke
-			tier = king
-			tier = emperor
-		}
-		OR = {
-			has_law = tribal_organization_1
-			has_law = tribal_organization_2
-			has_law = tribal_organization_3
-			has_law = tribal_organization_4
-		}
+		always = no
 	}
 	
 	is_valid = {
-		FROM = {
-			is_tribal = yes
-			in_revolt = no
-			liege_before_war = {
-				in_revolt = no
-				liege_before_war = {
-					in_revolt = no
-				}
-			}
-		}
-		ROOT = {
-			OR = {
-				liege = {
-					character = PREV # either independent
-				}
-				liege = { 
-					FROM = { 
-						is_liege_or_above = PREV # or have shared liege
-					}
-				}
-			}
-		}
-	}
-	
-	on_add = {
-		emf_cb_dynlevy_effect = yes
+		always = no
 	}
 
 	on_success = {
-		emf_cb_victory_effect = yes
-		emf_cb_dynlevy_effect = yes
-		
-		ROOT = {
-			opinion = {
-				modifier = opinion_lowered_tribal_organization
-				who = FROM
-				months = 12
-			}
-		}
-		any_attacker = {
-			limit = { character = ROOT }
-			participation_scaled_prestige = 100
-			hidden_tooltip = {
-				disband_event_forces = faction_revolters
-			}
-		}
-		any_attacker = {
-			limit = { NOT = { character = ROOT } }
-			hidden_tooltip = { participation_scaled_prestige = 100 }
-			hidden_tooltip = {
-				disband_event_forces = faction_revolters
-			}
-		}
-		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
-	}
-
-	on_success_title = {
-		if = {
-			limit = { has_law = tribal_organization_1 }
-			add_law_w_cooldown = tribal_organization_0
-		}
-		if = {
-			limit = { has_law = tribal_organization_2 }
-			add_law_w_cooldown = tribal_organization_1
-		}
-		if = {
-			limit = { has_law = tribal_organization_3 }
-			add_law_w_cooldown = tribal_organization_2
-		}
-		if = {
-			limit = { has_law = tribal_organization_4 }
-			add_law_w_cooldown = tribal_organization_3
-		}
 	}
 
 	on_fail = {
-		emf_cb_dynlevy_effect = yes
-		ROOT = {
-			prestige = -100
-		}
-		
-		any_defender = {
-			limit = { character = FROM }
-			participation_scaled_prestige = 50
-		}
-		any_defender = {
-			limit = { NOT = { character = FROM } }
-			hidden_tooltip = { participation_scaled_prestige = 50 }
-		}
-		
-		hidden_tooltip = {
-			any_attacker = {
-				disband_event_forces = faction_revolters
-				add_character_modifier = {
-					name = faction_lower_TO_ultimatum_timer
-					hidden = yes
-					duration = 3650
-				}
-			}
-		}
-		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
 	}
 
 	on_reverse_demand = {
-		emf_cb_defeat_effect = yes
-		emf_cb_dynlevy_effect = yes
-		ROOT = {
-			prestige = -200
-			prisoner = FROM
-		}
-		
-		any_defender = {
-			limit = { character = FROM }
-			participation_scaled_prestige = 100
-		}
-		any_defender = {
-			limit = { NOT = { character = FROM } }
-			hidden_tooltip = { participation_scaled_prestige = 100 }
-		}
-		
-		hidden_tooltip = {
-			any_attacker = {
-				limit = { liege = { character = FROM } }
-				prisoner = FROM
-				disband_event_forces = faction_revolters
-				add_character_modifier = {
-					name = faction_lower_TO_ultimatum_timer
-					hidden = yes
-					duration = 3650
-				}
-			}
-		}
-		FROM = { hidden_tooltip = { disband_event_forces = faction_loyalists } }
-	}
-
-	on_invalidation = {
-		emf_cb_dynlevy_effect = yes
 	}
 
 	attacker_ai_victory_worth = {
@@ -202,15 +60,5 @@ lower_tribal_organization_law = {
 	
 	defender_ai_defeat_worth = {
 		factor = 100
-	}
-	
-	# ai importance placed on this CB: scope is the targeted title, ROOT is the attacking character, FROM is the defending character
-	ai_will_do = { 
-		factor = 1
-		
-		modifier = {
-			factor = 10
-			FROM = { ai = no }
-		}
 	}
 }

--- a/EMF/common/cb_types/23_coastal_republic.txt
+++ b/EMF/common/cb_types/23_coastal_republic.txt
@@ -146,9 +146,11 @@ coastal_republic = {
 	}
 	
 	on_add = {
+		log = "CB(coastal_republic): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		if = {
 			limit = { not = { has_global_flag = emf_no_cooldowns } }
-			# Z: TODO: Give this a polished custom_tooltip
+			# FIXME: Give this a polished custom_tooltip
 			ROOT = {
 				add_character_modifier = {
 					name = emf_cb_mod_republic_cooldown
@@ -159,6 +161,8 @@ coastal_republic = {
 	}
 
 	on_success = {
+		log = "CB(coastal_republic): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		ROOT = { pf_prosperity_plus2_effect = yes }
 	}
@@ -203,6 +207,8 @@ coastal_republic = {
 	}   
 
 	on_fail = {
+		log = "CB(coastal_republic): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -100
 		}
@@ -217,6 +223,8 @@ coastal_republic = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(coastal_republic): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = { pf_prosperity_minus2_effect = yes }
 		ROOT = {
@@ -234,6 +242,10 @@ coastal_republic = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 100 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(coastal_republic): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/24_coastal_county_republic.txt
+++ b/EMF/common/cb_types/24_coastal_county_republic.txt
@@ -102,6 +102,8 @@ coastal_county_republic = {
 	}
 	
 	on_add = {
+		log = "CB(coastal_county_republic): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		if = {
 			limit = { not = { has_global_flag = emf_no_cooldowns } }
 			# FIXME: Give this a polished custom_tooltip
@@ -115,6 +117,8 @@ coastal_county_republic = {
 	}
 
 	on_success = {
+		log = "CB(coastal_county_republic): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		ROOT = { pf_prosperity_plus2_effect = yes }
 	}
@@ -169,6 +173,8 @@ coastal_county_republic = {
 	}
 
 	on_fail = {
+		log = "CB(coastal_county_republic): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -100
 		}
@@ -183,6 +189,8 @@ coastal_county_republic = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(coastal_county_republic): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = { pf_prosperity_minus2_effect = yes }
 		ROOT = {
@@ -200,6 +208,10 @@ coastal_county_republic = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 100 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(coastal_county_republic): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/25_weaken_vassal_plot.txt
+++ b/EMF/common/cb_types/25_weaken_vassal_plot.txt
@@ -51,7 +51,13 @@ weaken_vassal_plot = {
 		}
 	}
 
+	on_add = {
+		log = "CB(weaken_vassal_plot): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(weaken_vassal_plot): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		any_attacker = {
 			participation_scaled_prestige = 100
@@ -103,6 +109,8 @@ weaken_vassal_plot = {
 	}
 
 	on_fail = {
+		log = "CB(weaken_vassal_plot): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -100
 			cancel_plot = plot_weaken_fellow_vassal
@@ -118,6 +126,8 @@ weaken_vassal_plot = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(weaken_vassal_plot): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			prestige = -200
@@ -143,6 +153,10 @@ weaken_vassal_plot = {
 			}
 		}
 		end_war = invalid
+	}
+
+	on_invalidation = {
+		log = "CB(weaken_vassal_plot): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/26_decadence_invasion.txt
+++ b/EMF/common/cb_types/26_decadence_invasion.txt
@@ -30,7 +30,13 @@ decadence_invasion = {
 		ROOT = { has_character_flag = decadence_invader }
 	}
 
+	on_add = {
+		log = "CB(decadence_invasion): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(decadence_invasion): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		FROM = {
 			any_demesne_title = { # All titles
@@ -124,6 +130,8 @@ decadence_invasion = {
 	}
 
 	on_fail = {
+		log = "CB(decadence_invasion): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -200
 		}
@@ -144,6 +152,8 @@ decadence_invasion = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(decadence_invasion): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = { set_defacto_liege = FROM }
 		ROOT = {
@@ -176,6 +186,11 @@ decadence_invasion = {
 			remove_claim = PREV
 		}
 	}
+
+	on_invalidation = {
+		log = "CB(decadence_invasion): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 
 	attacker_ai_victory_worth = {
 		factor = 100

--- a/EMF/common/cb_types/27_muslim_invasion.txt
+++ b/EMF/common/cb_types/27_muslim_invasion.txt
@@ -144,7 +144,24 @@ muslim_invasion = {
 		}
 	}
 	
+	is_valid = {
+		ROOT = {
+			religion_group = muslim
+		}
+		FROM = { NOT = { religion = ROOT } }
+	}
+	
+	is_valid_title = {
+		FROM = {
+			any_realm_title = {
+				de_jure_liege_or_above = PREVPREV
+			}
+		}
+	}
+	
 	on_add = {
+		log = "CB(muslim_invasion): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = { piety = -1000 }
 		if = {
 			limit = { not = { has_global_flag = emf_no_cooldowns } }
@@ -161,23 +178,10 @@ muslim_invasion = {
 			}
 		}
 	}
-	
-	is_valid = {
-		ROOT = {
-			religion_group = muslim
-		}
-		FROM = { NOT = { religion = ROOT } }
-	}
-	
-	is_valid_title = {
-		FROM = {
-			any_realm_title = {
-				de_jure_liege_or_above = PREVPREV
-			}
-		}
-	}
 
 	on_success = {
+		log = "CB(muslim_invasion): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_victory_effect = yes
 		ROOT = {
 			prestige = 200
@@ -246,6 +250,8 @@ muslim_invasion = {
 	}
 
 	on_fail = {
+		log = "CB(muslim_invasion): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		FROM = {
 			prestige = 100
 		}
@@ -291,6 +297,8 @@ muslim_invasion = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(muslim_invasion): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_defeat_effect = yes
 		ROOT = {
 			prestige = -200
@@ -340,6 +348,10 @@ muslim_invasion = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 200 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(muslim_invasion): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/28_cb_faction_independence.txt
+++ b/EMF/common/cb_types/28_cb_faction_independence.txt
@@ -67,10 +67,14 @@ cb_faction_independence = {
 	}
 	
 	on_add = {
+		log = "CB(cb_faction_independence): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_dynlevy_effect = yes
 	}
 
 	on_success = {
+		log = "CB(cb_faction_independence): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		FROM = { pf_prosperity_minus2_effect = yes }
 
@@ -182,6 +186,8 @@ cb_faction_independence = {
 	}
 
 	on_fail = {
+		log = "CB(cb_faction_independence): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_dynlevy_effect = yes
 
 		ROOT = {
@@ -216,6 +222,8 @@ cb_faction_independence = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(cb_faction_independence): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		emf_cb_dynlevy_effect = yes
 
@@ -273,6 +281,8 @@ cb_faction_independence = {
 	}
 
 	on_invalidation = {
+		log = "CB(cb_faction_independence): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_dynlevy_effect = yes
 	}
 

--- a/EMF/common/cb_types/29_imperial_reconquest.txt
+++ b/EMF/common/cb_types/29_imperial_reconquest.txt
@@ -130,8 +130,14 @@ imperial_reconquest = {
 			not = { same_realm = FROM }
 		}
 	}
+
+	on_add = {
+		log = "CB(imperial_reconquest): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
 	
 	on_success = {
+		log = "CB(imperial_reconquest): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		any_attacker = {
 			limit = { character = ROOT }
@@ -254,10 +260,14 @@ imperial_reconquest = {
 	}
 
 	on_fail = {
+		log = "CB(imperial_reconquest): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = { prestige = -150 }
 	}
 
 	on_reverse_demand = {
+		log = "CB(imperial_reconquest): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			transfer_scaled_wealth = {
@@ -286,6 +296,10 @@ imperial_reconquest = {
 				}
 			}
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(imperial_reconquest): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/30_embargo_cb.txt
+++ b/EMF/common/cb_types/30_embargo_cb.txt
@@ -88,7 +88,13 @@ embargo_cb = {
 		}
 	}
 
+	on_add = {
+		log = "CB(embargo_cb): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(embargo_cb): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		ROOT = { pf_prosperity_minus4_effect = yes }
 		FROM = { pf_prosperity_minus4_effect = yes }
@@ -98,6 +104,8 @@ embargo_cb = {
 	}
 
 	on_fail = {
+		log = "CB(embargo_cb): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		if = {
 			limit = {
 				NOT = {
@@ -134,6 +142,8 @@ embargo_cb = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(embargo_cb): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		FROM = { pf_prosperity_plus4_effect = yes }
 		if = {
@@ -178,6 +188,10 @@ embargo_cb = {
 		FROM = {
 			prestige = 100
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(embargo_cb): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/31_seize_trade_post.txt
+++ b/EMF/common/cb_types/31_seize_trade_post.txt
@@ -113,7 +113,13 @@ seize_trade_post = {
 		}
 	}
 
+	on_add = {
+		log = "CB(seize_trade_post): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(seize_trade_post): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		ROOT = { pf_prosperity_plus2_effect = yes }
 		FROM = { pf_prosperity_minus2_effect = yes }
@@ -133,6 +139,8 @@ seize_trade_post = {
 	}
 
 	on_fail = {
+		log = "CB(seize_trade_post): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -50
 		}
@@ -147,6 +155,8 @@ seize_trade_post = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(seize_trade_post): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		FROM = { pf_prosperity_plus2_effect = yes }
 		ROOT = {
@@ -164,6 +174,10 @@ seize_trade_post = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 50 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(seize_trade_post): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/32_viking_invasion.txt
+++ b/EMF/common/cb_types/32_viking_invasion.txt
@@ -70,7 +70,13 @@ viking_invasion = {
 		}
 	}
 
+	on_add = {
+		log = "CB(viking_invasion): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(viking_invasion): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_victory_effect = yes
 		ROOT = {
 			prestige = 500
@@ -156,6 +162,8 @@ viking_invasion = {
 	}
 
 	on_fail = {
+		log = "CB(viking_invasion): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		FROM = {
 			prestige = 200
 		}
@@ -180,6 +188,8 @@ viking_invasion = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(viking_invasion): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_defeat_effect = yes
 		ROOT = {
 			prestige = -500
@@ -219,6 +229,10 @@ viking_invasion = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 250 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(viking_invasion): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/33_pagan_subjugation.txt
+++ b/EMF/common/cb_types/33_pagan_subjugation.txt
@@ -99,6 +99,8 @@ pagan_subjugation = {
 	}
 	
 	on_add = {
+		log = "CB(pagan_subjugation): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			add_character_modifier = { 
 				name = launched_subjugation
@@ -109,6 +111,8 @@ pagan_subjugation = {
 	}
 
 	on_success = {
+		log = "CB(pagan_subjugation): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		ROOT = {
 			piety = 50
@@ -246,6 +250,8 @@ pagan_subjugation = {
 	}
 
 	on_fail = {
+		log = "CB(pagan_subjugation): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		FROM = {
 			piety = 50
 		}
@@ -263,6 +269,8 @@ pagan_subjugation = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(pagan_subjugation): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			piety = -200
@@ -295,6 +303,10 @@ pagan_subjugation = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 100 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(pagan_subjugation): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/34_peasant_revolt.txt
+++ b/EMF/common/cb_types/34_peasant_revolt.txt
@@ -59,7 +59,13 @@ peasant_revolt = {
 		}
 	}
 
+	on_add = {
+		log = "CB(peasant_revolt): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(peasant_revolt): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 	}
 
@@ -73,7 +79,9 @@ peasant_revolt = {
 		}
 	}
 
-	on_fail_title = {
+	on_fail = {
+		log = "CB(peasant_revolt): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		FROM = {
 			prestige = 10
 			hidden_tooltip = {
@@ -97,6 +105,8 @@ peasant_revolt = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(peasant_revolt): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		FROM = {
 			prestige = 20
@@ -122,6 +132,10 @@ peasant_revolt = {
 				}
 			}
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(peasant_revolt): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/35_heretic_revolt.txt
+++ b/EMF/common/cb_types/35_heretic_revolt.txt
@@ -39,7 +39,13 @@ heretic_revolt = {
 		}
 	}
 
+	on_add = {
+		log = "CB(heretic_revolt): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(heretic_revolt): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_victory_effect = yes
 		ROOT = {
 			prestige = 200
@@ -59,6 +65,8 @@ heretic_revolt = {
 	}
 
 	on_fail = {
+		log = "CB(heretic_revolt): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			clear_wealth = yes
 			imprison = FROM
@@ -87,6 +95,8 @@ heretic_revolt = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(heretic_revolt): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_defeat_effect = yes
 		ROOT = {
 			clear_wealth = yes
@@ -117,6 +127,10 @@ heretic_revolt = {
 				modifier = won_heretic_revolt
 			}
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(heretic_revolt): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/36_religious_revolt.txt
+++ b/EMF/common/cb_types/36_religious_revolt.txt
@@ -38,8 +38,14 @@ religious_revolt = {
 			NOT = { religion = ROOT }
 		}
 	}
+
+	on_add = {
+		log = "CB(religious_revolt): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
  
 	on_success = {
+		log = "CB(religious_revolt): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_victory_effect = yes
 		ROOT = {
 			prestige = 200
@@ -59,6 +65,8 @@ religious_revolt = {
 	}
 
 	on_fail = {
+		log = "CB(religious_revolt): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			clear_wealth = yes
 			imprison = FROM
@@ -87,6 +95,8 @@ religious_revolt = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(religious_revolt): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_defeat_effect = yes
 		ROOT = {
 			clear_wealth = yes
@@ -117,6 +127,10 @@ religious_revolt = {
 				modifier = won_religious_revolt
 			}
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(religious_revolt): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/37_liberation_revolt.txt
+++ b/EMF/common/cb_types/37_liberation_revolt.txt
@@ -50,8 +50,14 @@ liberation_revolt = {
 	is_valid_title = {
 		has_holder = no
 	}
+
+	on_add = {
+		log = "CB(liberation_revolt): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
 	
 	on_success = {
+		log = "CB(liberation_revolt): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		ROOT = {
 			prestige = 1000
@@ -97,7 +103,9 @@ liberation_revolt = {
 		}
 	}
 
-	on_fail_title = {
+	on_fail = {
+		log = "CB(liberation_revolt): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		FROM = {
 			prestige = 100
 			hidden_tooltip = {
@@ -123,6 +131,8 @@ liberation_revolt = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(liberation_revolt): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		FROM = {
 			prestige = 200
@@ -150,6 +160,10 @@ liberation_revolt = {
 				remove_trait = inspiring_leader
 			}
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(liberation_revolt): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/38_duchy_adventure.txt
+++ b/EMF/common/cb_types/38_duchy_adventure.txt
@@ -34,8 +34,14 @@ duchy_adventure = {
 	is_valid = {
 		always = yes
 	}
+
+	on_add = {
+		log = "CB(duchy_adventure): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
 	
 	on_success = {
+		log = "CB(duchy_adventure): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		ROOT = { 
 			prestige = 250
@@ -104,6 +110,8 @@ duchy_adventure = {
 	}
 
 	on_fail = {
+		log = "CB(duchy_adventure): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		FROM = {
 			prestige = 100
 			hidden_tooltip = {
@@ -127,6 +135,8 @@ duchy_adventure = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(duchy_adventure): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			transfer_scaled_wealth = {
@@ -158,6 +168,10 @@ duchy_adventure = {
 			}
 		}
 		end_war = invalid
+	}
+
+	on_invalidation = {
+		log = "CB(duchy_adventure): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/40_caliphal_subjugation.txt
+++ b/EMF/common/cb_types/40_caliphal_subjugation.txt
@@ -75,6 +75,8 @@ caliphal_subjugation = {
 	}
 	
 	on_add = {
+		log = "CB(caliphal_subjugation): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			piety = -200
 			add_character_modifier = { 
@@ -86,6 +88,8 @@ caliphal_subjugation = {
 	}
 
 	on_success = {
+		log = "CB(caliphal_subjugation): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		ROOT = { pf_tradition_plus4_effect = yes }
 		ROOT = {
@@ -122,6 +126,8 @@ caliphal_subjugation = {
 	}
 
 	on_fail = {
+		log = "CB(caliphal_subjugation): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		FROM = {
 			prestige = 50
 		}
@@ -139,6 +145,8 @@ caliphal_subjugation = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(caliphal_subjugation): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = { pf_tradition_minus4_effect = yes }
 		ROOT = {
@@ -172,6 +180,10 @@ caliphal_subjugation = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 100 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(caliphal_subjugation): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/41_muslim_county_conquest.txt
+++ b/EMF/common/cb_types/41_muslim_county_conquest.txt
@@ -108,7 +108,13 @@ muslim_county_conquest = {
 		}
 	}
 
+	on_add = {
+		log = "CB(muslim_county_conquest): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(muslim_county_conquest): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 	}
 
@@ -168,7 +174,9 @@ muslim_county_conquest = {
 		}
 	}
 
-	on_fail_title = {
+	on_fail = {
+		log = "CB(muslim_county_conquest): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -100
 		}
@@ -183,6 +191,8 @@ muslim_county_conquest = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(muslim_county_conquest): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			prestige = -200
@@ -199,6 +209,10 @@ muslim_county_conquest = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 100 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(muslim_county_conquest): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/42_pagan_county_conquest.txt
+++ b/EMF/common/cb_types/42_pagan_county_conquest.txt
@@ -141,6 +141,8 @@ pagan_county_conquest = {
 	}
 	
 	on_add = {
+		log = "CB(pagan_county_conquest): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		if = {
 			limit = { not = { has_global_flag = emf_no_cooldowns } }
 			ROOT = {
@@ -158,6 +160,8 @@ pagan_county_conquest = {
 	}
 
 	on_success = {
+		log = "CB(pagan_county_conquest): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_victory_effect = yes
 	}
 
@@ -210,7 +214,9 @@ pagan_county_conquest = {
 		}
 	}
 
-	on_fail_title = {
+	on_fail = {
+		log = "CB(pagan_county_conquest): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -100
 		}
@@ -235,6 +241,8 @@ pagan_county_conquest = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(pagan_county_conquest): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_defeat_effect = yes
 		ROOT = {
 			prestige = -200
@@ -265,6 +273,10 @@ pagan_county_conquest = {
 				participation_scaled_piety = 50
 			}
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(pagan_county_conquest): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/43_dejure_county_claim.txt
+++ b/EMF/common/cb_types/43_dejure_county_claim.txt
@@ -195,7 +195,13 @@ dejure_county_claim = {
 		}
 	}
 
+	on_add = {
+		log = "CB(dejure_county_claim): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(dejure_county_claim): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 	}
 
@@ -257,7 +263,9 @@ dejure_county_claim = {
 		}
 	}
 
-	on_fail_title = {
+	on_fail = {
+		log = "CB(dejure_county_claim): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -100
 		}
@@ -272,6 +280,8 @@ dejure_county_claim = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(dejure_county_claim): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			prestige = -200
@@ -288,6 +298,10 @@ dejure_county_claim = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 100 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(dejure_county_claim): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/44_dejure_barony_claim.txt
+++ b/EMF/common/cb_types/44_dejure_barony_claim.txt
@@ -65,7 +65,13 @@ dejure_barony_claim = {
 		}
 	}
 
+	on_add = {
+		log = "CB(dejure_barony_claim): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(dejure_barony_claim): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 	}
 
@@ -102,7 +108,9 @@ dejure_barony_claim = {
 		}
 	}
 
-	on_fail_title = {
+	on_fail = {
+		log = "CB(dejure_barony_claim): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -50
 		}
@@ -117,6 +125,8 @@ dejure_barony_claim = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(dejure_barony_claim): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			prestige = -100
@@ -133,6 +143,10 @@ dejure_barony_claim = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 50 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(dejure_barony_claim): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/46_other_dejure_county_claim.txt
+++ b/EMF/common/cb_types/46_other_dejure_county_claim.txt
@@ -110,11 +110,11 @@ other_dejure_county_claim = {
 	}
 
 	on_add = {
-		log = "CB(other_dejure_county_claim): START: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_dejure_county_claim): START: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 	}
 
 	on_success = {
-		log = "CB(other_dejure_county_claim): VICTORY: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_dejure_county_claim): VICTORY: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 
 		emf_cb_victory_other_effect = yes
 		ROOT = {
@@ -182,7 +182,7 @@ other_dejure_county_claim = {
 	}
 
 	on_fail = {
-		log = "CB(other_dejure_county_claim): WHITEPEACE: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_dejure_county_claim): WHITEPEACE: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 
 		prestige = -50
 		ROOT = {
@@ -199,7 +199,7 @@ other_dejure_county_claim = {
 	}
 
 	on_reverse_demand = {
-		log = "CB(other_dejure_county_claim): DEFEAT: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_dejure_county_claim): DEFEAT: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 		
 		emf_cb_defeat_other_effect = yes
 		prestige = -100
@@ -221,7 +221,7 @@ other_dejure_county_claim = {
 	}
 
 	on_invalidation = {
-		log = "CB(other_dejure_county_claim): INVALIDATED: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		log = "CB(other_dejure_county_claim): INVALIDATED: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledFirstName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/46_other_dejure_county_claim.txt
+++ b/EMF/common/cb_types/46_other_dejure_county_claim.txt
@@ -109,7 +109,13 @@ other_dejure_county_claim = {
 		}
 	}
 
+	on_add = {
+		log = "CB(other_dejure_county_claim): START: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+	}
+
 	on_success = {
+		log = "CB(other_dejure_county_claim): VICTORY: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+
 		emf_cb_victory_other_effect = yes
 		ROOT = {
 			opinion = {
@@ -176,6 +182,8 @@ other_dejure_county_claim = {
 	}
 
 	on_fail = {
+		log = "CB(other_dejure_county_claim): WHITEPEACE: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+
 		prestige = -50
 		ROOT = {
 			prestige = -100
@@ -191,6 +199,8 @@ other_dejure_county_claim = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(other_dejure_county_claim): DEFEAT: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
+		
 		emf_cb_defeat_other_effect = yes
 		prestige = -100
 		transfer_scaled_wealth = {
@@ -208,6 +218,10 @@ other_dejure_county_claim = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 100 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(other_dejure_county_claim): INVALIDATED: full_title=[FromFrom.GetFullBaseName]: [This.GetTitledName] of [This.PrimaryTitle.GetBaseName] (ID: [This.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID]) on behalf of [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/47_shia_caliphate_rising.txt
+++ b/EMF/common/cb_types/47_shia_caliphate_rising.txt
@@ -52,7 +52,13 @@ shia_caliphate_rising = {
 		}
 	}
 
+	on_add = {
+		log = "CB(shia_caliphate_rising): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(shia_caliphate_rising): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_victory_effect = yes
 		clr_global_flag = shia_caliphate_revolt_ongoing
 		ROOT = {
@@ -147,6 +153,8 @@ shia_caliphate_rising = {
 	}
 
 	on_fail = {
+		log = "CB(shia_caliphate_rising): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		clr_global_flag = shia_caliphate_revolt_ongoing
 		FROM = {
 			piety = 250
@@ -158,6 +166,8 @@ shia_caliphate_rising = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(shia_caliphate_rising): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_defeat_effect = yes
 		
 		clr_global_flag = shia_caliphate_revolt_ongoing
@@ -188,6 +198,8 @@ shia_caliphate_rising = {
 	}
 
 	on_invalidation = {
+		log = "CB(shia_caliphate_rising): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		clr_global_flag = shia_caliphate_revolt_ongoing
 	}
 	

--- a/EMF/common/cb_types/48_depose_antipope.txt
+++ b/EMF/common/cb_types/48_depose_antipope.txt
@@ -79,8 +79,14 @@ depose_antipope = {
 			}
 		}
 	}
+
+	on_add = {
+		log = "CB(depose_antipope): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
 	
 	on_success = {
+		log = "CB(depose_antipope): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_victory_effect = yes
 		any_attacker = {
 			limit = { character = ROOT }
@@ -132,6 +138,8 @@ depose_antipope = {
 	}
 
 	on_fail = {
+		log = "CB(depose_antipope): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = { 
 			piety = -250
 			prestige = -125
@@ -143,6 +151,8 @@ depose_antipope = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(depose_antipope): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_defeat_effect = yes
 		ROOT = {
 			transfer_scaled_wealth = {
@@ -157,6 +167,10 @@ depose_antipope = {
 			piety = 500
 			prestige = 250
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(depose_antipope): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/49_cb_install_antiking.txt
+++ b/EMF/common/cb_types/49_cb_install_antiking.txt
@@ -71,10 +71,14 @@ cb_install_antiking = {
 	}
 	
 	on_add = {
+		log = "CB(cb_install_antiking): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_dynlevy_effect = yes
 	}
 	
 	on_success = {
+		log = "CB(cb_install_antiking): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		emf_cb_dynlevy_effect = yes
 		
@@ -147,6 +151,8 @@ cb_install_antiking = {
 	}
 
 	on_fail = {
+		log = "CB(cb_install_antiking): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_dynlevy_effect = yes
 		
 		ROOT = { 
@@ -161,6 +167,8 @@ cb_install_antiking = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(cb_install_antiking): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		emf_cb_dynlevy_effect = yes
 		
@@ -182,6 +190,8 @@ cb_install_antiking = {
 	}
 
 	on_invalidation = {
+		log = "CB(cb_install_antiking): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_dynlevy_effect = yes
 	}
 

--- a/EMF/common/cb_types/50_buddhist_holy_war.txt
+++ b/EMF/common/cb_types/50_buddhist_holy_war.txt
@@ -145,10 +145,14 @@ buddhist_holy_war = {
 	}
 
 	on_add = {
+		log = "CB(buddhist_holy_war): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = { piety = -100 }
 	}
 	
 	on_success = {
+		log = "CB(buddhist_holy_war): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_victory_effect = yes
 	}
 
@@ -208,7 +212,9 @@ buddhist_holy_war = {
 		}
 	}
 
-	on_fail_title = {
+	on_fail = {
+		log = "CB(buddhist_holy_war): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -100
 		}
@@ -223,6 +229,8 @@ buddhist_holy_war = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(buddhist_holy_war): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_holy_defeat_effect = yes
 		ROOT = {
 			prestige = -200
@@ -239,6 +247,10 @@ buddhist_holy_war = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 100 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(buddhist_holy_war): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/51_indian_subjugation.txt
+++ b/EMF/common/cb_types/51_indian_subjugation.txt
@@ -43,10 +43,6 @@ indian_subjugation = {
 		}
 	}
 	
-	on_add = {
-		ROOT = { piety = -500 }
-	}
-	
 	can_use = {
 		ROOT = {
 			religion_group = indian_group
@@ -101,6 +97,12 @@ indian_subjugation = {
 		}
 	}
 	
+	on_add = {
+		log = "CB(indian_subjugation): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
+		ROOT = { piety = -500 }
+	}
+	
 	on_add_title = {
 		ROOT = {
 			if = {
@@ -124,6 +126,8 @@ indian_subjugation = {
 	}
 
 	on_success = {
+		log = "CB(indian_subjugation): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		any_attacker = {
 			limit = { character = ROOT }
@@ -200,6 +204,8 @@ indian_subjugation = {
 	}
 
 	on_fail = {
+		log = "CB(indian_subjugation): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		any_defender = {
 			limit = { character = FROM }
 			participation_scaled_prestige = 100
@@ -214,6 +220,8 @@ indian_subjugation = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(indian_subjugation): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			prestige = -200
@@ -230,6 +238,10 @@ indian_subjugation = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 200 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(indian_subjugation): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/52_manifest_destiny_invasion.txt
+++ b/EMF/common/cb_types/52_manifest_destiny_invasion.txt
@@ -120,7 +120,13 @@ manifest_destiny_invasion = {
 		}
 	}
 
+	on_add = {
+		log = "CB(manifest_destiny_invasion): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(manifest_destiny_invasion): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		ROOT = {
 			prestige = 200
@@ -189,6 +195,8 @@ manifest_destiny_invasion = {
 	}
 
 	on_fail = {
+		log = "CB(manifest_destiny_invasion): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		FROM = {
 			prestige = 100
 		}
@@ -219,6 +227,8 @@ manifest_destiny_invasion = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(manifest_destiny_invasion): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			prestige = -200
@@ -252,6 +262,10 @@ manifest_destiny_invasion = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 200 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(manifest_destiny_invasion): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/53_cb_decadence_usurption.txt
+++ b/EMF/common/cb_types/53_cb_decadence_usurption.txt
@@ -67,8 +67,14 @@ cb_decadence_usurption = {
 			}
 		}
 	}
+
+	on_add = {
+		log = "CB(cb_decadence_usurption): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
 	
 	on_success = {
+		log = "CB(cb_decadence_usurption): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		any_attacker = {
 			limit = { character = ROOT }
@@ -96,6 +102,8 @@ cb_decadence_usurption = {
 	}
 
 	on_fail = {
+		log = "CB(cb_decadence_usurption): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = { 
 			piety = -250
 			prestige = -125
@@ -107,6 +115,8 @@ cb_decadence_usurption = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(cb_decadence_usurption): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			transfer_scaled_wealth = {
@@ -121,6 +131,10 @@ cb_decadence_usurption = {
 			piety = 500
 			prestige = 250
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(cb_decadence_usurption): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/54_rivalry_cb.txt
+++ b/EMF/common/cb_types/54_rivalry_cb.txt
@@ -50,8 +50,14 @@ rivalry_cb = {
 			is_rival = FROM
 		}
 	}
+
+	on_add = {
+		log = "CB(rivalry_cb): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
 	
 	on_success = {
+		log = "CB(rivalry_cb): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		
 		any_attacker = {
@@ -97,6 +103,8 @@ rivalry_cb = {
 	}
 
 	on_fail = {
+		log = "CB(rivalry_cb): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = { 
 			prestige = -125
 		}
@@ -106,6 +114,8 @@ rivalry_cb = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(rivalry_cb): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		any_defender = {
 			limit = { character = FROM }
@@ -148,6 +158,10 @@ rivalry_cb = {
 				set_character_flag = achievement_sibling_rival_war
 			}
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(rivalry_cb): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/55_tributary_cb.txt
+++ b/EMF/common/cb_types/55_tributary_cb.txt
@@ -126,7 +126,13 @@ tributary_cb = {
 		}
 	}
 
+	on_add = {
+		log = "CB(tributary_cb): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(tributary_cb): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		
 		FROM = {
@@ -202,6 +208,8 @@ tributary_cb = {
 	}
 
 	on_fail = {
+		log = "CB(tributary_cb): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -100
 		}
@@ -211,6 +219,8 @@ tributary_cb = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(tributary_cb): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		
 		ROOT = {
@@ -228,6 +238,10 @@ tributary_cb = {
 	
 	on_attacker_leader_death = {
 		end_war = invalid
+	}
+
+	on_invalidation = {
+		log = "CB(tributary_cb): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/56_free_tributary_cb.txt
+++ b/EMF/common/cb_types/56_free_tributary_cb.txt
@@ -91,7 +91,13 @@ free_tributary_cb = {
 		}
 	}
 
+	on_add = {
+		log = "CB(free_tributary_cb): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(free_tributary_cb): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		
 		FROM = {
@@ -136,6 +142,8 @@ free_tributary_cb = {
 	}
 
 	on_fail = {
+		log = "CB(free_tributary_cb): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -100
 		}
@@ -145,6 +153,8 @@ free_tributary_cb = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(free_tributary_cb): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			prestige = -100
@@ -157,6 +167,10 @@ free_tributary_cb = {
 		FROM = {
 			prestige = 100
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(free_tributary_cb): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	on_attacker_leader_death = {

--- a/EMF/common/cb_types/57_cb_install_khan.txt
+++ b/EMF/common/cb_types/57_cb_install_khan.txt
@@ -66,10 +66,14 @@ cb_install_khan = {
 	}
 
 	on_add = {
+		log = "CB(cb_install_khan): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_dynlevy_effect = yes
 	}
 	
 	on_success = {
+		log = "CB(cb_install_khan): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		
 		FROM = {
@@ -96,6 +100,8 @@ cb_install_khan = {
 	}
 
 	on_fail = {
+		log = "CB(cb_install_khan): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_dynlevy_effect = yes
 		
 		ROOT = {
@@ -104,6 +110,8 @@ cb_install_khan = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(cb_install_khan): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		emf_cb_dynlevy_effect = yes
 		
@@ -142,6 +150,8 @@ cb_install_khan = {
 	}
 
 	on_invalidation = {
+		log = "CB(cb_install_khan): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_dynlevy_effect = yes
 	}
 

--- a/EMF/common/cb_types/58_nomad_dispute.txt
+++ b/EMF/common/cb_types/58_nomad_dispute.txt
@@ -72,7 +72,13 @@ nomad_dispute = {
 		}
 	}
 
+	on_add = {
+		log = "CB(): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 	}
 
@@ -95,7 +101,9 @@ nomad_dispute = {
 		}
 	}
 
-	on_fail_title = {
+	on_fail = {
+		log = "CB(): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -100
 		}
@@ -110,6 +118,8 @@ nomad_dispute = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			prestige = -200
@@ -130,6 +140,10 @@ nomad_dispute = {
 				participation_scaled_piety = 50
 			}
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/60_cb_minor_clan_revolt.txt
+++ b/EMF/common/cb_types/60_cb_minor_clan_revolt.txt
@@ -59,7 +59,13 @@ cb_minor_clan_revolt = {
 		}
 	}
 
+	on_add = {
+		log = "CB(cb_minor_clan_revolt): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+
 	on_success = {
+		log = "CB(cb_minor_clan_revolt): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 	}
 
@@ -92,7 +98,9 @@ cb_minor_clan_revolt = {
 		}
 	}
 
-	on_fail_title = {
+	on_fail = {
+		log = "CB(cb_minor_clan_revolt): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		FROM = {
 			prestige = 10
 			hidden_tooltip = {
@@ -116,6 +124,8 @@ cb_minor_clan_revolt = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(cb_minor_clan_revolt): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		FROM = {
 			prestige = 20
@@ -145,6 +155,10 @@ cb_minor_clan_revolt = {
 
 	on_attacker_leader_death = {
 		end_war = invalid
+	}
+
+	on_invalidation = {
+		log = "CB(cb_minor_clan_revolt): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/61_nomad_subjugation.txt
+++ b/EMF/common/cb_types/61_nomad_subjugation.txt
@@ -86,6 +86,8 @@ nomad_subjugation = {
 	}
 	
 	on_add = {
+		log = "CB(nomad_subjugation): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			add_character_modifier = { 
 				name = launched_subjugation
@@ -96,6 +98,8 @@ nomad_subjugation = {
 	}
 
 	on_success = {
+		log = "CB(nomad_subjugation): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		ROOT = {
 			piety = 100
@@ -233,6 +237,8 @@ nomad_subjugation = {
 	}
 	
 	on_fail = {
+		log = "CB(nomad_subjugation): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		FROM = {
 			piety = 50
 		}
@@ -250,6 +256,8 @@ nomad_subjugation = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(nomad_subjugation): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			piety = -200
@@ -282,6 +290,10 @@ nomad_subjugation = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 100 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(nomad_subjugation): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/62_nomad_invasion.txt
+++ b/EMF/common/cb_types/62_nomad_invasion.txt
@@ -83,13 +83,18 @@ nomad_invasion = {
 		}
 	}
 
+	
 	on_add = {
+		log = "CB(nomad_invasion): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = {
 			prestige = -100
 		}
 	}
-
+	
 	on_success = {
+		log = "CB(nomad_invasion): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		ROOT = {
 			prestige = 200
@@ -146,6 +151,8 @@ nomad_invasion = {
 	}
 
 	on_fail = {
+		log = "CB(nomad_invasion): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		FROM = {
 			prestige = 100
 			
@@ -178,6 +185,8 @@ nomad_invasion = {
 	}
 
 	on_reverse_demand = {
+		log = "CB(nomad_invasion): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			prestige = -200
@@ -223,6 +232,10 @@ nomad_invasion = {
 			limit = { NOT = { character = FROM } }
 			hidden_tooltip = { participation_scaled_prestige = 200 }
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(nomad_invasion): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/63_nomad_expansion.txt
+++ b/EMF/common/cb_types/63_nomad_expansion.txt
@@ -81,7 +81,13 @@ nomad_expansion = {
 		}
 	}
 	
+	on_add = {
+		log = "CB(nomad_expansion): START: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+	}
+	
 	on_success = {
+		log = "CB(nomad_expansion): VICTORY: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_victory_effect = yes
 		any_attacker = {
 			limit = { character = ROOT }
@@ -126,12 +132,16 @@ nomad_expansion = {
 	}
 
 	on_fail = {
+		log = "CB(nomad_expansion): WHITEPEACE: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		ROOT = { 
 			prestige = -200
 		}
 	}
 
 	on_reverse_demand = {
+		log = "CB(nomad_expansion): DEFEAT: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			transfer_scaled_wealth = {
@@ -162,6 +172,10 @@ nomad_expansion = {
 				}
 			}
 		}
+	}
+
+	on_invalidation = {
+		log = "CB(nomad_expansion): INVALIDATED: title=[ThirdPartyTitle.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/PB_RapidConquest.txt
+++ b/EMF/common/cb_types/PB_RapidConquest.txt
@@ -80,11 +80,11 @@ minor_conquest = {
 	}
 
 	on_add = {
-		log = "CB(minor_conquest): START: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(minor_conquest): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	on_success = {
-		log = "CB(minor_conquest): VICTORY: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(minor_conquest): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 
 		emf_cb_victory_effect = yes
 		ROOT = {
@@ -108,7 +108,7 @@ minor_conquest = {
 	}
 	
 	on_fail = {
-		log = "CB(minor_conquest): WHITEPEACE: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(minor_conquest): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 
 		ROOT = {
 			prestige = -25
@@ -116,7 +116,7 @@ minor_conquest = {
 	}
 	
 	on_reverse_demand = {
-		log = "CB(minor_conquest): DEFEAT: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(minor_conquest): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 
 		emf_cb_defeat_effect = yes
 		ROOT = {
@@ -132,7 +132,7 @@ minor_conquest = {
 	}
 
 	on_invalidation = {
-		log = "CB(minor_conquest): INVALIDATED: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(minor_conquest): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	attacker_ai_victory_worth = {
@@ -210,11 +210,11 @@ subjugation = {
 	}
 	
 	on_add = {
-		log = "CB(subjugation): START: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(subjugation): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
-		log = "CB(subjugation): VICTORY: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(subjugation): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_victory_effect = yes
 		ROOT = {
 			prestige = 100
@@ -230,14 +230,14 @@ subjugation = {
 	}
 	
 	on_fail = {
-		log = "CB(subjugation): WHITEPEACE: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(subjugation): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		ROOT = {
 			prestige = -25
 		}
 	}
 	
 	on_reverse_demand = {
-		log = "CB(subjugation): DEFEAT: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(subjugation): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			prestige = -50
@@ -252,7 +252,7 @@ subjugation = {
 	}
 
 	on_invalidation = {
-		log = "CB(subjugation): INVALIDATED: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(subjugation): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {
@@ -326,11 +326,11 @@ subjugation_duke = {
 	}
 
 	on_add = {
-		log = "CB(subjugation_duke): START: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(subjugation_duke): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	on_success = {
-		log = "CB(subjugation_duke): VICTORY: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(subjugation_duke): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_victory_effect = yes
 		ROOT = {
 			prestige = 100
@@ -342,14 +342,14 @@ subjugation_duke = {
 	}
 	
 	on_fail = {
-		log = "CB(subjugation_duke): WHITEPEACE: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(subjugation_duke): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		ROOT = {
 			prestige = -25
 		}
 	}
 	
 	on_reverse_demand = {
-		log = "CB(subjugation_duke): DEFEAT: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(subjugation_duke): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_defeat_effect = yes
 		ROOT = {
 			prestige = -50
@@ -364,7 +364,7 @@ subjugation_duke = {
 	}
 
 	on_invalidation = {
-		log = "CB(subjugation_duke): INVALIDATED: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(subjugation_duke): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/cb_faction_overthrow_ruler.txt
+++ b/EMF/common/cb_types/cb_faction_overthrow_ruler.txt
@@ -53,11 +53,11 @@ cb_faction_overthrow_ruler = {
 	}
 
 	on_add = {
-		log = "CB(cb_faction_overthrow_ruler): START: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(cb_faction_overthrow_ruler): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
-		log = "CB(cb_faction_overthrow_ruler): VICTORY: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(cb_faction_overthrow_ruler): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		# mark who the attackers are, for later
 		hidden_tooltip = { 
 			any_attacker = {
@@ -326,7 +326,7 @@ cb_faction_overthrow_ruler = {
 	}
 
 	on_fail = {
-		log = "CB(cb_faction_overthrow_ruler): WHITEPEACE: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(cb_faction_overthrow_ruler): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		# re-vassalize the rebels
 		pf_cb_revassalize_rebels_effect = yes
 		ROOT = {
@@ -354,7 +354,7 @@ cb_faction_overthrow_ruler = {
 	}
 
 	on_reverse_demand = {
-		log = "CB(cb_faction_overthrow_ruler): DEFEAT: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(cb_faction_overthrow_ruler): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		hidden_tooltip = {
 			# mark rebels as civil war losers
 			any_attacker = {
@@ -416,7 +416,7 @@ cb_faction_overthrow_ruler = {
 	}
 
 	on_invalidation = {
-		log = "CB(cb_faction_overthrow_ruler): INVALIDATED: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(cb_faction_overthrow_ruler): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		# re-vassalize the rebels
 		pf_cb_revassalize_rebels_effect = yes
 		hidden_tooltip = {

--- a/EMF/common/cb_types/emf_dejure_duchy_claim.txt
+++ b/EMF/common/cb_types/emf_dejure_duchy_claim.txt
@@ -147,7 +147,7 @@ emf_dejure_duchy_claim = {
 	}
 
 	on_add_title = {
-		log = "CB(emf_dejure_duchy_claim): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_dejure_duchy_claim): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
@@ -155,7 +155,7 @@ emf_dejure_duchy_claim = {
 	}
 
 	on_success_title = {
-		log = "CB(): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_nomadic_province_effect = yes
 		
 		FROM = {
@@ -192,7 +192,7 @@ emf_dejure_duchy_claim = {
 	}
 
 	on_fail_title = {
-		log = "CB(emf_dejure_duchy_claim): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_dejure_duchy_claim): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -215,11 +215,11 @@ emf_dejure_duchy_claim = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(emf_dejure_duchy_claim): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_dejure_duchy_claim): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_invalidation = {
-		log = "CB(emf_dejure_duchy_claim): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_dejure_duchy_claim): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/emf_dejure_kingdom_claim.txt
+++ b/EMF/common/cb_types/emf_dejure_kingdom_claim.txt
@@ -99,7 +99,7 @@ emf_dejure_kingdom_claim = {
 	}
 
 	on_add_title = {
-		log = "CB(emf_dejure_kingdom_claim): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_dejure_kingdom_claim): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
@@ -107,7 +107,7 @@ emf_dejure_kingdom_claim = {
 	}
 
 	on_success_title = {
-		log = "CB(emf_dejure_kingdom_claim): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_dejure_kingdom_claim): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_nomadic_province_effect = yes
 		FROM = {
 			prestige = -200
@@ -129,7 +129,7 @@ emf_dejure_kingdom_claim = {
 	}
 
 	on_fail_title = {
-		log = "CB(emf_dejure_kingdom_claim): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_dejure_kingdom_claim): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_fail = {
@@ -147,7 +147,7 @@ emf_dejure_kingdom_claim = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(emf_dejure_kingdom_claim): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_dejure_kingdom_claim): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -170,7 +170,7 @@ emf_dejure_kingdom_claim = {
 	}
 
 	on_invalidation = {
-		log = "CB(): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/emf_horde_invasion.txt
+++ b/EMF/common/cb_types/emf_horde_invasion.txt
@@ -74,7 +74,7 @@ emf_horde_invasion = {
 	}
 
 	on_add_title = {
-		log = "CB(emf_horde_invasion): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_horde_invasion): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
@@ -118,7 +118,7 @@ emf_horde_invasion = {
 	}
 	
 	on_success_title = {
-		log = "CB(emf_horde_invasion): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_horde_invasion): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_nomadic_province_effect = yes
 		
 		custom_tooltip = {
@@ -180,7 +180,7 @@ emf_horde_invasion = {
 	}
 
 	on_fail_title = {
-		log = "CB(emf_horde_invasion): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_horde_invasion): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -235,11 +235,11 @@ emf_horde_invasion = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(emf_horde_invasion): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_horde_invasion): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_invalidation = {
-		log = "CB(emf_horde_invasion): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_horde_invasion): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/emf_liberate_nomad_county.txt
+++ b/EMF/common/cb_types/emf_liberate_nomad_county.txt
@@ -125,7 +125,7 @@ emf_liberate_nomad_county = {
 	}
 
 	on_add_title = {
-		log = "CB(emf_liberate_nomad_county): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_liberate_nomad_county): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
@@ -158,7 +158,7 @@ emf_liberate_nomad_county = {
 	}
 
 	on_success_title = {
-		log = "CB(emf_liberate_nomad_county): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_liberate_nomad_county): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_nomadic_province_effect = yes
 		
 		custom_tooltip = {
@@ -185,7 +185,7 @@ emf_liberate_nomad_county = {
 	}
 
 	on_fail_title = {
-		log = "CB(emf_liberate_nomad_county): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_liberate_nomad_county): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -222,11 +222,11 @@ emf_liberate_nomad_county = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(emf_liberate_nomad_county): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_liberate_nomad_county): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_invalidation = {
-		log = "CB(emf_liberate_nomad_county): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_liberate_nomad_county): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/emf_magyar867_invasion.txt
+++ b/EMF/common/cb_types/emf_magyar867_invasion.txt
@@ -44,7 +44,7 @@ emf_magyar867_invasion = {
 	}
 
 	on_add_title = {
-		log = "CB(emf_magyar867_invasion): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_magyar867_invasion): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
@@ -66,7 +66,7 @@ emf_magyar867_invasion = {
 	}
 	
 	on_success_title = {
-		log = "CB(emf_magyar867_invasion): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_magyar867_invasion): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_nomadic_province_effect = yes
 		
 		custom_tooltip = {
@@ -165,7 +165,7 @@ emf_magyar867_invasion = {
 	}
 
 	on_fail_title = {
-		log = "CB(emf_magyar867_invasion): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_magyar867_invasion): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -214,11 +214,11 @@ emf_magyar867_invasion = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(emf_magyar867_invasion): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_magyar867_invasion): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_invalidation = {
-		log = "CB(emf_magyar867_invasion): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_magyar867_invasion): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		hidden_tooltip = {
 			if = {
 				limit = { has_dlc = "Horse Lords" }

--- a/EMF/common/cb_types/emf_muslim_county_conquest_religious.txt
+++ b/EMF/common/cb_types/emf_muslim_county_conquest_religious.txt
@@ -138,7 +138,7 @@ emf_muslim_county_conquest_religious = {
 	}
 
 	on_add_title = {
-		log = "CB(emf_muslim_county_conquest_religious): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_muslim_county_conquest_religious): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	on_success = {
@@ -146,7 +146,7 @@ emf_muslim_county_conquest_religious = {
 	}
 
 	on_success_title = {
-		log = "CB(emf_muslim_county_conquest_religious): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_muslim_county_conquest_religious): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		if = {
 			limit = {
 				holder_scope = {
@@ -202,7 +202,7 @@ emf_muslim_county_conquest_religious = {
 	}
 
 	on_fail_title = {
-		log = "CB(emf_muslim_county_conquest_religious): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_muslim_county_conquest_religious): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		ROOT = {
 			prestige = -100
 		}
@@ -236,11 +236,11 @@ emf_muslim_county_conquest_religious = {
 	}
 	
 	on_reverse_demand_title = {
-		log = "CB(emf_muslim_county_conquest_religious): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_muslim_county_conquest_religious): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_invalidation = {
-		log = "CB(emf_muslim_county_conquest_religious): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_muslim_county_conquest_religious): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/emf_religious_reconquest.txt
+++ b/EMF/common/cb_types/emf_religious_reconquest.txt
@@ -303,7 +303,7 @@ emf_religious_reconquest = {
 	}
 
 	on_add_title = {
-		log = "CB(emf_religious_reconquest): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_religious_reconquest): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	on_success = {
@@ -351,7 +351,7 @@ emf_religious_reconquest = {
 	}
 
 	on_success_title = {
-		log = "CB(emf_religious_reconquest): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_religious_reconquest): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_nomadic_province_effect = yes
 		
 		custom_tooltip = {
@@ -427,11 +427,11 @@ emf_religious_reconquest = {
 	}
 	
 	on_reverse_demand_title = {
-		log = "CB(emf_religious_reconquest): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_religious_reconquest): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_invalidation = {
-		log = "CB(emf_religious_reconquest): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_religious_reconquest): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/emf_restore_hre.txt
+++ b/EMF/common/cb_types/emf_restore_hre.txt
@@ -369,7 +369,7 @@ emf_restore_hre = {
 	}
 
 	on_add_title = {
-		log = "CB(emf_restore_hre): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_restore_hre): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
@@ -398,7 +398,7 @@ emf_restore_hre = {
 	}
 
 	on_success_title = {
-		log = "CB(emf_restore_hre): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_restore_hre): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		usurp_title_plus_barony_if_unlanded = { target = ROOT type = claim }
 
 		FROM = {
@@ -447,7 +447,7 @@ emf_restore_hre = {
 	}
 
 	on_fail_title = {
-		log = "CB(emf_restore_hre): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_restore_hre): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -478,11 +478,11 @@ emf_restore_hre = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(emf_restore_hre): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_restore_hre): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_invalidation = {
-		log = "CB(emf_restore_hre): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_restore_hre): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/emf_special_religious.txt
+++ b/EMF/common/cb_types/emf_special_religious.txt
@@ -286,7 +286,7 @@ emf_special_religious = {
 	}
 
 	on_add_title = {
-		log = "CB(emf_special_religious): START: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_special_religious): START: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
@@ -334,7 +334,7 @@ emf_special_religious = {
 	}
 
 	on_success_title = {
-		log = "CB(emf_special_religious): VICTORY: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_special_religious): VICTORY: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 		emf_cb_nomadic_province_effect = yes
 		
 		custom_tooltip = {
@@ -360,7 +360,7 @@ emf_special_religious = {
 	}
 
 	on_fail_title = {
-		log = "CB(emf_special_religious): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_special_religious): WHITEPEACE: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_reverse_demand = {
@@ -413,11 +413,11 @@ emf_special_religious = {
 	}
 
 	on_reverse_demand_title = {
-		log = "CB(emf_special_religious): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_special_religious): DEFEAT: title=[This.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_invalidation = {
-		log = "CB(emf_special_religious): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_special_religious): INVALIDATED: title=[FromFrom.GetBaseName]: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	attacker_ai_victory_worth = {

--- a/EMF/common/cb_types/emf_subjugation.txt
+++ b/EMF/common/cb_types/emf_subjugation.txt
@@ -165,11 +165,11 @@ emf_subjugation = {
 	}
 
 	on_add = {
-		log = "CB(emf_subjugation): START: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_subjugation): START: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 
 	on_success = {
-		log = "CB(emf_subjugation): VICTORY: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_subjugation): VICTORY: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 
 		emf_cb_victory_effect = yes
 		
@@ -222,7 +222,7 @@ emf_subjugation = {
 	}
 	
 	on_fail = {
-		log = "CB(emf_subjugation): WHITEPEACE: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_subjugation): WHITEPEACE: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 
 		ROOT = {
 			if = {
@@ -241,7 +241,7 @@ emf_subjugation = {
 	}
 	
 	on_reverse_demand = {
-		log = "CB(emf_subjugation): DEFEAT: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_subjugation): DEFEAT: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 
 		emf_cb_defeat_effect = yes
 		
@@ -300,7 +300,7 @@ emf_subjugation = {
 	}
 
 	on_invalidation = {
-		log = "CB(emf_subjugation): INVALIDATED: [Root.GetTitledName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
+		log = "CB(emf_subjugation): INVALIDATED: [Root.GetTitledFirstName] of [Root.PrimaryTitle.GetBaseName] (ID: [Root.GetID]) vs. [From.GetTitledFirstName] of [From.PrimaryTitle.GetBaseName] (ID: [From.GetID])"
 	}
 	
 	attacker_ai_victory_worth = {


### PR DESCRIPTION
Previous methodology for CB logging is still present in CBs: vanilla 1-19, and all EMF, PB, and Plus CBs. However, usage of `[GetTitledName]` was correctly replaced with `[GetTitledFirstName]` (which resolves that messed-up logging thing you pointed-out @escalonn) in these too.

Remaining CBs, vanilla 20-63 now use a new methodology for logging (which will no doubt have its failings as well...).

A few CBs, such as Lower Tribal Organization were deactivated (although their factions are still in place-- TODO), and there is still no logging in the succession law faction CBs, since I intend to pipe those through the PF code like @Rylock has just done in Plus.