### PR TITLE
Iberia

### DIFF
--- a/EMF/common/cb_types/14_religious.txt
+++ b/EMF/common/cb_types/14_religious.txt
@@ -173,21 +173,6 @@ religious = {
 					not = { religion_group = FROM }
 				}
 			}
-			and = {
-				ROOT = {
-					religion_group = christian
-					not = { religion_group = FROM }
-					capital_scope = {
-						region = world_europe_west_iberia
-					}
-				}
-				not = { title = d_granada }
-				any_direct_de_jure_vassal_title = {
-					location = {
-						region = world_europe_west_iberia
-					}
-				}
-			}
 		}
 
 		# Prefer 'Religious Reconquest' CB

--- a/EMF/common/cb_types/emf_religious_reconquest.txt
+++ b/EMF/common/cb_types/emf_religious_reconquest.txt
@@ -144,21 +144,6 @@ emf_religious_reconquest = {
 					not = { religion_group = FROM }
 				}
 			}
-			and = {
-				ROOT = {
-					religion_group = christian
-					not = { religion_group = FROM }
-					capital_scope = {
-						region = world_europe_west_iberia
-					}
-				}
-				not = { title = d_granada }
-				any_direct_de_jure_vassal_title = {
-					location = {
-						region = world_europe_west_iberia
-					}
-				}
-			}
 		}
 
 		# The attacker needs at least one county in the target duchy, or a land

--- a/EMF/common/cb_types/emf_special_religious.txt
+++ b/EMF/common/cb_types/emf_special_religious.txt
@@ -128,20 +128,6 @@ emf_special_religious = {
 				de_jure_liege = k_jerusalem
 				ROOT = { has_landed_title = k_jerusalem }
 			}
-			and = {
-				ROOT = {
-					religion_group = christian
-					capital_scope = {
-						region = world_europe_west_iberia
-					}
-				}
-				not = { title = d_granada }
-				any_direct_de_jure_vassal_title = {
-					location = {
-						region = world_europe_west_iberia
-					}
-				}
-			}
 		}
 
 		# The attacker needs at least one county in the target duchy, or a land

--- a/EMF/events/emf_historical.txt
+++ b/EMF/events/emf_historical.txt
@@ -149,8 +149,6 @@ character_event = {
 					}
 				}
 			}
-			culture = event_target:new_owner
-			religion = event_target:new_owner
 			county = {
 				grant_title_no_opinion = event_target:new_owner
 				any_direct_de_jure_vassal_title = {
@@ -314,6 +312,12 @@ character_event = {
 				de_jure_liege = k_portugal
 				# Prevent reassignment if it drifts-out again
 				has_title_flag = emf_iberia_assimilated
+				# Don't drift out of a kingdom held by a christian
+				kingdom = {
+					holder_scope = {
+						religion_group = christian
+					}
+				}
 			}
 			ROOT = { completely_controls = PREV }
 			# Prevent weird corner cases that might cause de jure border gore
@@ -365,6 +369,12 @@ character_event = {
 				de_jure_liege = k_portugal
 				# Prevent reassignment if it drifts-out again
 				has_title_flag = emf_iberia_assimilated
+				# Don't drift out of a kingdom held by a christian
+				kingdom = {
+					holder_scope = {
+						religion_group = christian
+					}
+				}
 			}
 			emf_core_ROOT_completely_controls_duchy_counties_trigger = yes
 			# Prevent weird corner cases that might cause de jure border gore
@@ -419,6 +429,12 @@ character_event = {
 				de_jure_liege = k_castille
 				# Prevent reassignment if it drifts-out again
 				has_title_flag = emf_iberia_assimilated
+				# Don't drift out of a kingdom held by a christian
+				kingdom = {
+					holder_scope = {
+						religion_group = christian
+					}
+				}
 			}
 			emf_core_ROOT_completely_controls_duchy_counties_trigger = yes
 			# Prevent weird corner cases that might cause de jure border gore
@@ -513,6 +529,12 @@ character_event = {
 				de_jure_liege = k_aragon
 				# Prevent reassignment if it drifts-out again
 				has_title_flag = emf_iberia_assimilated
+				# Don't drift out of a kingdom held by a christian
+				kingdom = {
+					holder_scope = {
+						religion_group = christian
+					}
+				}
 			}
 			emf_core_ROOT_completely_controls_duchy_counties_trigger = yes
 			# Prevent weird corner cases that might cause de jure border gore
@@ -638,6 +660,12 @@ character_event = {
 				de_jure_liege = k_aragon
 				# Prevent reassignment if it drifts-out again
 				has_title_flag = emf_iberia_assimilated
+				# Don't drift out of a kingdom held by a christian
+				kingdom = {
+					holder_scope = {
+						religion_group = christian
+					}
+				}
 			}
 			emf_core_ROOT_completely_controls_duchy_counties_trigger = yes
 			# Prevent weird corner cases that might cause de jure border gore
@@ -762,6 +790,12 @@ character_event = {
 				de_jure_liege = k_aragon
 				# Prevent reassignment if it drifts-out again
 				has_title_flag = emf_iberia_assimilated
+				# Don't drift out of a kingdom held by a christian
+				kingdom = {
+					holder_scope = {
+						religion_group = christian
+					}
+				}
 			}
 			emf_core_ROOT_completely_controls_duchy_counties_trigger = yes
 			# Prevent weird corner cases that might cause de jure border gore
@@ -856,6 +890,12 @@ character_event = {
 				de_jure_liege = k_aragon
 				# Prevent reassignment if it drifts-out again
 				has_title_flag = emf_iberia_assimilated
+				# Don't drift out of a kingdom held by a christian
+				kingdom = {
+					holder_scope = {
+						religion_group = christian
+					}
+				}
 			}
 			emf_core_ROOT_completely_controls_duchy_counties_trigger = yes
 			# Prevent weird corner cases that might cause de jure border gore
@@ -946,6 +986,12 @@ character_event = {
 				de_jure_liege = k_aragon
 				# Prevent reassignment if it drifts-out again
 				has_title_flag = emf_iberia_assimilated
+				# Don't drift out of a kingdom held by a christian
+				kingdom = {
+					holder_scope = {
+						religion_group = christian
+					}
+				}
 			}
 			emf_core_ROOT_completely_controls_duchy_counties_trigger = yes
 			# Prevent weird corner cases that might cause de jure border gore

--- a/EMF/events/emf_historical.txt
+++ b/EMF/events/emf_historical.txt
@@ -685,6 +685,7 @@ character_event = {
 				}
 				and = {
 					ROOT = { has_landed_title = k_leon }
+					d_toledo = { de_jure_liege = k_leon }
 					any_direct_de_jure_vassal_title = {
 						location = {
 							any_neighbor_province = {
@@ -737,6 +738,7 @@ character_event = {
 			if = {
 				limit = {
 					ROOT = { has_landed_title = k_leon }
+					d_toledo = { de_jure_liege = k_leon }
 					any_direct_de_jure_vassal_title = {
 						location = {
 							any_neighbor_province = {


### PR DESCRIPTION
- Christian Iberians again must use the standard *Holy War* CB (which costs piety)
- Iberian De Jure Expansion:
  - Never drift duchies out of a kingdom held by a Christian
  - `k_leon` may not drift `d_la_mancha` unless/until it's already drifted `d_toledo`