### PR TITLE
No mo' viceroyalties

### DIFF
--- a/EMF/common/laws/emf_demesne_laws.txt
+++ b/EMF/common/laws/emf_demesne_laws.txt
@@ -1560,7 +1560,7 @@ laws = {
 				hidden_tooltip = {
 					OR = {
 						has_law = revokation_2
-						holder_scope = { primary_title = { has_law = ze_revokation_2 } }
+						has_law = ze_revokation_2
 					}
 				}
 			}

--- a/EMF/common/laws/emf_demesne_laws.txt
+++ b/EMF/common/laws/emf_demesne_laws.txt
@@ -16,10 +16,6 @@ law_groups = {
 		law_type = realm
 		allowed_for_councillors = yes
 	}
-	vice_royalty = {
-		law_type = realm
-		allowed_for_councillors = yes
-	}
 	protected_appointment = {
 		law_type = realm
 		allowed_for_councillors = yes
@@ -1391,18 +1387,7 @@ laws = {
 				revoke_law = administration_1
 				revoke_law = administration_2
 			}
-			if = {
-				limit = { 
-					NOT = { has_dlc = "Charlemagne" } 
-				}
-				set_allow_free_duchy_revokation = no
-			}
-			if = {
-				limit = { 
-					has_dlc = "Charlemagne" 
-				}
-				set_allow_free_vice_royalty_revokation = no
-			}
+			set_allow_free_duchy_revokation = no
 		}
 		revoke_allowed = {
 			always = no
@@ -1509,18 +1494,7 @@ laws = {
 				revoke_law = administration_1
 				revoke_law = administration_2
 			}
-			if = {
-				limit = { 
-					NOT = { has_dlc = "Charlemagne" } 
-				}
-				set_allow_free_duchy_revokation = no
-			}
-			if = {
-				limit = { 
-					has_dlc = "Charlemagne" 
-				}
-				set_allow_free_vice_royalty_revokation = no
-			}
+			set_allow_free_duchy_revokation = no
 			if = {
 				limit = {
 					has_law = administration_0
@@ -1581,13 +1555,19 @@ laws = {
 			has_law = administration_1
 			has_law = crown_authority_4
 			has_law = inheritance_1
-			OR = { # FIXME: Could use a custom tooltip to avoid a tooltip of OR = { 2 things that are identical }
-				has_law = revokation_2
-				has_law = ze_revokation_2
+			custom_tooltip = {
+				text = emf_laws_ctt_free_infidel_revocation_trigger
+				hidden_tooltip = {
+					OR = {
+						has_law = revokation_2
+						holder_scope = { primary_title = { has_law = ze_revokation_2 } }
+					}
+				}
 			}
 			NOT = { has_law = king_peace_0 }
 		}
 		effect = {
+			set_allow_free_duchy_revokation = yes
 			if = {
 				limit = { has_law = administration_0 }
 				custom_tooltip = { text = emf_laws_ctt_enables_succ_primogeniture }
@@ -1600,24 +1580,23 @@ laws = {
 				revoke_law = administration_2
 			}
 			if = {
-				limit = { 
-					NOT = { has_dlc = "Charlemagne" } 
-				}
-				set_allow_free_duchy_revokation = yes
-			}
-			if  = {
 				limit = {
-					has_dlc = "Charlemagne"
-				}
-				add_law = vice_royalty_2
-				set_allow_free_vice_royalty_revokation = yes
-			}
-			if = {
-				limit = {
-					has_law = administration_1
+					OR = {
+						has_law = administration_0
+						has_law = administration_1
+					}
 					NOT = { holder_scope = { has_character_flag = emf_no_law_penalties } }
 				}
-				emf_laws_change_succ_prestige_cost_effect = yes
+				custom_tooltip = { text = emf_laws_ctt_administration_2_opinion_effect }
+				holder_scope = { prestige = -1000 }
+				hidden_tooltip = {
+					holder_scope = {
+						any_vassal = {
+							limit = { is_playable = yes }
+							opinion = { who = PREV modifier = opinion_adminstration_2_enacted }
+						}
+					}
+				}
 			}
 		}
 		revoke_allowed = {
@@ -1630,124 +1609,8 @@ laws = {
 			factor = 0
 		}
 		
-		vassal_limit = 25
-		feudal_opinion = -10
-	}
-	
-	# VICE ROYALTY LAWS
-	##############################
-	
-	vice_royalty_0 = {
-		group = vice_royalty
-		default = yes
-		
-		potential = {
-			higher_tier_than = king
-			holder_scope = {
-				independent = yes
-				is_feudal = yes
-			}
-			has_dlc = "Charlemagne"
-		}
-		revoke_allowed = {
-			always = no
-		}			
-		ai_will_do = {
-			factor = 0
-		}
-		ai_will_revoke = {
-			factor = 0
-		}
-		effect = {
-			hidden_tooltip = {
-				revoke_law = vice_royalty_0
-				revoke_law = vice_royalty_1
-				revoke_law = vice_royalty_2
-			}
-			set_allow_vice_royalties = no
-		}
-	}
-
-	vice_royalty_1 = {
-		group = vice_royalty
-		
-		potential = {
-			higher_tier_than = king
-			holder_scope = {
-				independent = yes
-				is_feudal = yes
-			}
-			has_dlc = "Charlemagne"
-		}
-		revoke_allowed = {
-			always = no
-		}			
-		ai_will_do = {
-			factor = 0 # AI shouldn't use viceroys unless forced
-			modifier = {
-				factor = 0
-				has_law = vice_royalty_2
-			}
-			modifier = {
-				factor = 0
-				has_law = vice_royalty_0
-				over_vassal_limit = -5
-			}
-		}
-		ai_will_revoke = {
-			factor = 0
-		}
-		effect = {
-			hidden_tooltip = {
-				revoke_law = vice_royalty_0
-				revoke_law = vice_royalty_1
-				revoke_law = vice_royalty_2
-			}
-			set_allow_vice_royalties = king
-		}
-		
-		vassal_limit = -5
-	}
-	
-	vice_royalty_2 = {
-		group = vice_royalty
-		
-		potential = {
-			higher_tier_than = king
-			holder_scope = {
-				independent = yes
-				is_feudal = yes
-			}
-			has_dlc = "Charlemagne"
-		}
-		revoke_allowed = {
-			always = no
-		}			
-		ai_will_do = {
-			factor = 3
-			modifier = {
-				factor = 0
-				has_law = vice_royalty_0
-			}
-			modifier = {
-				factor = 0
-				has_law = vice_royalty_1
-				over_vassal_limit = -5
-			}
-		}
-		ai_will_revoke = {
-			factor = 0
-		}
-		effect = {
-			hidden_tooltip = {
-				revoke_law = vice_royalty_0
-				revoke_law = vice_royalty_1
-				revoke_law = vice_royalty_2
-			}
-			set_allow_vice_royalties = duke
-		}
-		
-		vassal_limit = -10
+		vassal_limit = 15
+		vassal_opinion = -10 # FIXME: test that regular vassal_opinion (instead of feudal_opinion) works for laws
 	}
 
 	# PROTECTED COUNCIL APPOINTMENTS

--- a/EMF/common/on_actions/emf_on_actions.txt
+++ b/EMF/common/on_actions/emf_on_actions.txt
@@ -2,11 +2,11 @@
 #character
 on_startup = {
 	events = {
+		emf_laws.100 # Upgrade to EMF 5.03 laws ##TMP-SAVE-COMPAT##
 		emf_startup.2 # General campaign startup (runs only upon new campaign)
 		emf_coa.1 # Dynamic CoA adjustments
 		emf_startup.40 # Ensure [almost] every king-tier title has a de jure empire or e_null
 		emf_gender_eq.6 # Gender equality maintenance
-		emf_laws.100 # Upgrade to EMF 5.03 laws ##TMP-SAVE-COMPAT##
 	}
 }
 

--- a/EMF/common/opinion_modifiers/emf_laws_opinion_modifiers.txt
+++ b/EMF/common/opinion_modifiers/emf_laws_opinion_modifiers.txt
@@ -23,7 +23,7 @@ opinion_succ_former_pretender = {
 	months = 1
 }
 
-# Protected Council Appointments
+## Protected Council Appointments ##
 
 # for powerful vassal voters at all times whenever protected_appointment_1 is the law
 opinion_protected_appointment_always = {
@@ -41,4 +41,12 @@ opinion_protected_appointment_enacted = {
 opinion_protected_appointment_revoked = {
 	opinion = -10
 	months = 60
+}
+
+## Administration ##
+
+opinion_adminstration_2_enacted = {
+	opinion = -15
+	months = 360
+#	inherit = yes
 }

--- a/EMF/events/emf_laws.txt
+++ b/EMF/events/emf_laws.txt
@@ -1206,6 +1206,9 @@ character_event = {
 # emf_laws.100 [Isis]
 #
 # Law upgrades for EMF 5.03+, on_startup ##TMP-SAVE-COMPAT##
+# Note that I'm not bothering w/ converting the viceroyalty change. This is because this entire save-compatibility
+# measure is actually unnecessary (though helpful for protected_appointment law in alpha testing) due to SWMH
+# breaking save-compatibility for the Zeus4 HIP release.
 character_event = {
 	id = emf_laws.100
 	
@@ -1233,7 +1236,9 @@ character_event = {
 					has_law = protected_appointment_1
 				}
 			}
+			owner = { set_character_flag = emf_no_law_penalties }
 			add_law = protected_appointment_0
+			owner = { clr_character_flag = emf_no_law_penalties }
 		}
 	}
 }

--- a/EMF/localisation/zz~emf_laws.csv
+++ b/EMF/localisation/zz~emf_laws.csv
@@ -29,6 +29,7 @@ emf_laws_ctt_opinion_increase_authority;Opinion of §R-15§! from all rulers affec
 emf_laws_ctt_prevents_internal_military_plots;Prevents internal vassal military plots\n;;;;;;;;;;;;;x
 emf_laws_ctt_protected_appointment_0_effect;Any member of the ruling council may be dismissed at will.\n;;;;;;;;;;;;;x
 emf_laws_ctt_protected_appointment_1_effect;Powerful vassals may no longer be dismissed from the council-- so long as they remain powerful.\nThey will appreciate this protection with an additional §G+10§! opinion, a bonus which will apply to not only current but also all future powerful-vassal council members.\n;;;;;;;;;;;;;x
+emf_laws_ctt_administration_2_opinion_effect;Count- and above-tier direct vassal opinion of §R-15§! for §Y30§! years\n;;;;;;;;;;;;;x
 ### Triggers ###
 emf_laws_ctt_no_other_laws_passed;No other laws in this group have been passed\n;;;;;;;;;;;;;x
 emf_laws_ctt_ca_change_cooldown;Crown Authority for the §Y[This.GetFullName]§! may only be raised once per lifetime\n;;;;;;;;;;;;;x
@@ -56,6 +57,7 @@ emf_laws_ctt_king_tier_and_requires_750_prestige_cost;Tier is §YKING§! and can a
 emf_laws_ctt_emperor_tier_and_requires_1000_prestige_cost;Tier is §YEMPEROR§! and can afford cost of §R1000§! prestige\n;;;;;;;;;;;;;x
 emf_laws_ctt_player_if_muslim_or_indian;Is NOT AI-controlled, unless religion group is neither §MMuslim§! NOR §MIndian§!\n;;;;;;;;;;;;;x
 emf_laws_ctt_protected_appointment_0_allow;Enacted §YProtected Council Appointments§! at least §Y20§! years ago\n;;;;;;;;;;;;;x
+emf_laws_ctt_free_infidel_revocation_trigger;Has the law §YFree Infidel Title Revocation§!\n;;;;;;;;;;;;;x
 ### Succession Law Changes ###
 emf_laws_ctt_succ_change_child_reactions;§YChildren's Reaction:§!\n;;;;;;;;;;;;;x
 emf_laws_ctt_succ_change_reaction_to_pretenders;§YReaction to New Pretenders:§!\n;;;;;;;;;;;;;x
@@ -279,6 +281,7 @@ opinion_good_succ_law_change;Pleased by Succession Law Change;Satisfaction face 
 opinion_succ_law_change;Upset by Succession Law Change;Inquiétude face à la nouvelle loi de succession;Aufgebracht durch Nachfolgerechtsänderung;;Molesto por el cambio en la ley de sucesión;;;;;;;;;x
 opinion_succ_former_heir;Heir Before Succession Law Change;;;;;;;;;;;;;x
 opinion_succ_former_pretender;Pretender Before Succession Law Change;;;;;;;;;;;;;x
+opinion_adminstration_2_enacted;Enacted Imperial Administration;;;;;;;;;;;;;x
 opinion_protected_appointment_always;Protects My Council Appointment;;;;;;;;;;;;;x
 opinion_protected_appointment_enacted;Enacted Council Appointment Protection;;;;;;;;;;;;;x
 opinion_protected_appointment_revoked;Revoked Council Appointment Protection;;;;;;;;;;;;;x


### PR DESCRIPTION
... but free duchy revocation instead, until the imperial government form and viceroy replacement system which @Rylock is currently designing is ready for us to begin collaboration. Succession laws still support viceroyalties (though I will eventually remove that later), so this will still work w/ existing saves without much disruption.